### PR TITLE
use zaehlung.isKreisverkehr if fahrbez.isKreuzung is null

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,10 +11,10 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Advance Security Policy as Code
-        uses: advanced-security/policy-as-code@v2.1.2
+        uses: advanced-security/policy-as-code@v2.5.0
         with:
           policy: GeekMasher/security-queries
-          policy-path: policies/default.yml
+          policy-path: $GITHUB_WORKSPACE/policies/default.yml
 
           token: ${{ secrets.ACCESS_TOKEN }}
 

--- a/src/main/java/de/muenchen/dave/services/auswertung/AuswertungVisumService.java
+++ b/src/main/java/de/muenchen/dave/services/auswertung/AuswertungVisumService.java
@@ -16,7 +16,6 @@ import de.muenchen.dave.repositories.elasticsearch.ZaehlstelleIndex;
 import de.muenchen.dave.services.ladezaehldaten.LadeZaehldatenService;
 import de.muenchen.dave.util.ZaehldatenProcessingUtil;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
@@ -78,7 +77,7 @@ public class AuswertungVisumService {
                             .map(zaehlung -> {
                                 // Extrahieren der Zähldaten für alle Fahrbeziehungen einer Zählung
                                 final List<FahrbeziehungVisumDTO> fahrbeziehungenVisum = zaehlung.getFahrbeziehungen().stream()
-                                        .map(AuswertungVisumService::getFahrbeziehungenVisum)
+                                        .map(fz -> AuswertungVisumService.getFahrbeziehungenVisum(fz, zaehlung))
                                         .flatMap(Collection::stream)
                                         // Entfernen von eventuell auftretenden Duplikaten
                                         .distinct()
@@ -124,10 +123,11 @@ public class AuswertungVisumService {
      * @param fahrbeziehung Fahrbeziehung
      * @return die Visum-relevanten Fahrbeziehungsobjekte zur Extraktion der Zeitintervalle.
      */
-    public static List<FahrbeziehungVisumDTO> getFahrbeziehungenVisum(final Fahrbeziehung fahrbeziehung) {
+    public static List<FahrbeziehungVisumDTO> getFahrbeziehungenVisum(final Fahrbeziehung fahrbeziehung, final Zaehlung zaehlung) {
         final List<FahrbeziehungVisumDTO> fahrbeziehungenVisum = new ArrayList<>();
         FahrbeziehungVisumDTO fahrbeziehungVisum;
-        if (BooleanUtils.isTrue(fahrbeziehung.getIsKreuzung())) {
+        boolean isKreuzung = fahrbeziehung.getIsKreuzung() == null ? !zaehlung.getKreisverkehr() : fahrbeziehung.getIsKreuzung();
+        if (isKreuzung) {
             fahrbeziehungVisum = new FahrbeziehungVisumDTO();
             fahrbeziehungVisum.setVon(fahrbeziehung.getVon());
             fahrbeziehungVisum.setNach(null);

--- a/src/test/java/de/muenchen/dave/services/auswertung/AuswertungVisumServiceTest.java
+++ b/src/test/java/de/muenchen/dave/services/auswertung/AuswertungVisumServiceTest.java
@@ -53,7 +53,10 @@ class AuswertungVisumServiceTest {
         secondExpected.setNach(99);
         List<FahrbeziehungVisumDTO> expectedList = Arrays.asList(firstExpected, secondExpected);
 
-        assertThat(AuswertungVisumService.getFahrbeziehungenVisum(fahrbeziehung), is(expectedList));
+        var zaehlung = new Zaehlung();
+        zaehlung.setKreisverkehr(false);
+
+        assertThat(AuswertungVisumService.getFahrbeziehungenVisum(fahrbeziehung, zaehlung), is(expectedList));
 
         // Kreisverkehr Hinein
         fahrbeziehung = new Fahrbeziehung();
@@ -71,7 +74,7 @@ class AuswertungVisumServiceTest {
         secondExpected.setNach(55);
         expectedList = Arrays.asList(firstExpected, secondExpected);
 
-        assertThat(AuswertungVisumService.getFahrbeziehungenVisum(fahrbeziehung), is(expectedList));
+        assertThat(AuswertungVisumService.getFahrbeziehungenVisum(fahrbeziehung, zaehlung), is(expectedList));
 
         // Kreisverkehr Heraus
         fahrbeziehung = new Fahrbeziehung();
@@ -89,7 +92,7 @@ class AuswertungVisumServiceTest {
         secondExpected.setNach(56);
         expectedList = Arrays.asList(firstExpected, secondExpected);
 
-        assertThat(AuswertungVisumService.getFahrbeziehungenVisum(fahrbeziehung), is(expectedList));
+        assertThat(AuswertungVisumService.getFahrbeziehungenVisum(fahrbeziehung, zaehlung), is(expectedList));
 
         // Kreisverkehr Vorbei
         fahrbeziehung = new Fahrbeziehung();
@@ -107,7 +110,7 @@ class AuswertungVisumServiceTest {
         secondExpected.setNach(57);
         expectedList = Arrays.asList(firstExpected, secondExpected);
 
-        assertThat(AuswertungVisumService.getFahrbeziehungenVisum(fahrbeziehung), is(expectedList));
+        assertThat(AuswertungVisumService.getFahrbeziehungenVisum(fahrbeziehung, zaehlung), is(expectedList));
     }
 
     @Test


### PR DESCRIPTION
**Description**

The report for VISUM EAI is invalid when the switch isKreuzung of Fahrbeziehung is not set. This fix solves this by evaluating the switch isKreisverkehr of Zählung when isKreuzung is null.

**Reference**

Issues #XXX
