### PR TITLE
Feat/dave 157 farbige messstellen

### DIFF
--- a/src/main/java/de/muenchen/dave/domain/dtos/ErhebungsstelleKarteDTO.java
+++ b/src/main/java/de/muenchen/dave/domain/dtos/ErhebungsstelleKarteDTO.java
@@ -1,4 +1,5 @@
 package de.muenchen.dave.domain.dtos;
+
 import de.muenchen.dave.domain.enums.MessstelleStatus;
 import java.io.Serializable;
 import lombok.Data;

--- a/src/main/java/de/muenchen/dave/domain/dtos/ErhebungsstelleKarteDTO.java
+++ b/src/main/java/de/muenchen/dave/domain/dtos/ErhebungsstelleKarteDTO.java
@@ -1,8 +1,6 @@
 package de.muenchen.dave.domain.dtos;
-
-import java.io.Serializable;
-
 import de.muenchen.dave.domain.enums.MessstelleStatus;
+import java.io.Serializable;
 import lombok.Data;
 
 @Data

--- a/src/main/java/de/muenchen/dave/domain/dtos/ErhebungsstelleKarteDTO.java
+++ b/src/main/java/de/muenchen/dave/domain/dtos/ErhebungsstelleKarteDTO.java
@@ -1,6 +1,8 @@
 package de.muenchen.dave.domain.dtos;
 
 import java.io.Serializable;
+
+import de.muenchen.dave.domain.enums.MessstelleStatus;
 import lombok.Data;
 
 @Data
@@ -15,6 +17,8 @@ public class ErhebungsstelleKarteDTO implements Serializable {
     private Double longitude;
 
     private Double latitude;
+
+    private MessstelleStatus status;
 
     private ErhebungsstelleTooltipDTO tooltip;
 

--- a/src/main/java/de/muenchen/dave/services/SucheService.java
+++ b/src/main/java/de/muenchen/dave/services/SucheService.java
@@ -428,8 +428,7 @@ public class SucheService {
 
     /**
      * Befüllt ErhebungsstelleKarteDTO mit den entsprechenden Daten der Messstelle zum Anzeigen auf
-     * einer Karte und
-     * liefert diese zurück
+     * einer Karte und liefert diese zurück
      *
      * @param messstellen messstellen, die in ErhebungsstelleKarteDTOs umgewandelt werden sollen
      * @return Ein Set von befüllten ErhebungsstelleKarteDTOs
@@ -444,6 +443,7 @@ public class SucheService {
             erhebungsstelleKarteDTO.setLongitude(messstelle.getPunkt().getLon());
             erhebungsstelleKarteDTO.setFachId(messstelle.getMstId());
             erhebungsstelleKarteDTO.setType("messstelle");
+            erhebungsstelleKarteDTO.setStatus(messstelle.getStatus());
 
             erhebungsstelleKarteDTO.setTooltip(SucheMapper.createMessstelleTooltip(messstelle));
 


### PR DESCRIPTION
## Pull Request 

### Description

Messstellen werden auf der Karte als Diamanten angezeigt. Je nach Status haben die Diamanten unterschiedliche Farben (Violett, Orange oder Rot).

### Reference

Jira Ticket [DAVE-157 KFZ-Detektordaten - farbliche Darstellung Messstellen -Adminportal](https://jira.muenchen.de/browse/DAVE-157)

### Definition of Done
- [ ] Acceptance criteria are met
- [ ] Build/Test workflow has successfully finished
- [ ] Release notes are complemented
- [ ] Documentation is complemented (operator manual, system specification)
- [ ] Frontend is locally smoke-tested
- [ ] Side branches are deleted
- [ ] Board is updated
- [ ] Infrastructure is adjusted
