### PR TITLE
bug/zeitraum-wird-nicht-ausgewertet into sprint

### DIFF
--- a/src/main/java/de/muenchen/dave/services/messstelle/MesswerteService.java
+++ b/src/main/java/de/muenchen/dave/services/messstelle/MesswerteService.java
@@ -11,6 +11,8 @@ import de.muenchen.dave.geodateneai.gen.model.MeasurementValuesPerInterval;
 import de.muenchen.dave.geodateneai.gen.model.MeasurementValuesResponse;
 import de.muenchen.dave.geodateneai.gen.model.TotalSumPerMessquerschnitt;
 import de.muenchen.dave.util.OptionsUtil;
+import java.time.LocalDate;
+import java.util.Collections;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -72,11 +74,13 @@ public class MesswerteService {
         if (StringUtils.isNotEmpty(options.getTagesTyp())) {
             request.setTagesTyp(GetMeasurementValuesRequest.TagesTypEnum.valueOf(options.getTagesTyp()));
         }
-        request.setZeitpunktEnde(options.getZeitraum().get(0));
         if (options.getZeitraum().size() == 2) {
-            request.setZeitpunktStart(options.getZeitraum().get(1));
+            Collections.sort(options.getZeitraum());
+            request.setZeitpunktStart(options.getZeitraum().get(0));
+            request.setZeitpunktEnde(options.getZeitraum().get(1));
         } else {
             request.setZeitpunktStart(options.getZeitraum().get(0));
+            request.setZeitpunktEnde(options.getZeitraum().get(0));
         }
         request.setUhrzeitStart(options.getZeitblock().getStart().toLocalTime());
         request.setUhrzeitEnde(options.getZeitblock().getEnd().toLocalTime());

--- a/src/main/java/de/muenchen/dave/services/messstelle/MesswerteService.java
+++ b/src/main/java/de/muenchen/dave/services/messstelle/MesswerteService.java
@@ -11,7 +11,6 @@ import de.muenchen.dave.geodateneai.gen.model.MeasurementValuesPerInterval;
 import de.muenchen.dave.geodateneai.gen.model.MeasurementValuesResponse;
 import de.muenchen.dave.geodateneai.gen.model.TotalSumPerMessquerschnitt;
 import de.muenchen.dave.util.OptionsUtil;
-import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
 import lombok.AllArgsConstructor;

--- a/src/main/java/de/muenchen/dave/services/messstelle/MesswerteService.java
+++ b/src/main/java/de/muenchen/dave/services/messstelle/MesswerteService.java
@@ -72,11 +72,11 @@ public class MesswerteService {
         if (StringUtils.isNotEmpty(options.getTagesTyp())) {
             request.setTagesTyp(GetMeasurementValuesRequest.TagesTypEnum.valueOf(options.getTagesTyp()));
         }
-        request.setZeitpunktStart(options.getZeitraum().get(0));
+        request.setZeitpunktEnde(options.getZeitraum().get(0));
         if (options.getZeitraum().size() == 2) {
-            request.setZeitpunktEnde(options.getZeitraum().get(1));
+            request.setZeitpunktStart(options.getZeitraum().get(1));
         } else {
-            request.setZeitpunktEnde(options.getZeitraum().get(0));
+            request.setZeitpunktStart(options.getZeitraum().get(0));
         }
         request.setUhrzeitStart(options.getZeitblock().getStart().toLocalTime());
         request.setUhrzeitEnde(options.getZeitblock().getEnd().toLocalTime());


### PR DESCRIPTION
- Der Zeitraum wird nicht richtig ausgewertet, weil das mitgeschickte array falsch ausgelesen wird. 
- Reihenfolge geändert