### PR TITLE
Verwenden des OS-Servicenamen in Hazelcast-Config

### DIFF
--- a/src/main/java/de/muenchen/dave/configuration/CachingConfiguration.java
+++ b/src/main/java/de/muenchen/dave/configuration/CachingConfiguration.java
@@ -43,7 +43,7 @@ public class CachingConfiguration {
     public String hazelcastInstanceName;
     @Value("${hazelcast.group-name:data_hazl_group}")
     public String groupConfigName;
-    @Value("${hazelcast.openshift-service-name:dave-backend}")
+    @Value("${hazelcast.openshift-service-name:dave-backend-service}")
     public String openshiftServiceName;
 
     @Bean

--- a/src/main/java/de/muenchen/dave/configuration/CachingConfiguration.java
+++ b/src/main/java/de/muenchen/dave/configuration/CachingConfiguration.java
@@ -43,7 +43,7 @@ public class CachingConfiguration {
     public String hazelcastInstanceName;
     @Value("${hazelcast.group-name:data_hazl_group}")
     public String groupConfigName;
-    @Value("${hazelcast.openshift-service-name:backend}")
+    @Value("${hazelcast.openshift-service-name:dave-backend}")
     public String openshiftServiceName;
 
     @Bean


### PR DESCRIPTION
Verwenden des OS-Servicenamen in Hazelcast-Config