### PR TITLE
Anpassen Renovate Config zur Vermeidung der Setzung spezieller Minor und Patch-Release bei Github-Actions

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -3,4 +3,14 @@
   extends: [
     "github>it-at-m/refarch//refarch-tools/refarch-renovate/refarch-renovate-config.json5",
   ],
+  "packageRules": [
+    {
+      "description": "Only allow major standard upgrades for github actions.",
+      "matchDepTypes": [
+        "action"
+      ],
+      "rangeStrategy": "replace",
+      "pinDigests": false
+    }
+  ]
 }


### PR DESCRIPTION
Siehe Titel