### PR TITLE
FV-262 Filtermenue Zaehlungsvergleich Zeitreihe

### DIFF
--- a/src/main/java/de/muenchen/dave/services/pdfgenerator/FillZeitreihePdfBeanService.java
+++ b/src/main/java/de/muenchen/dave/services/pdfgenerator/FillZeitreihePdfBeanService.java
@@ -178,7 +178,7 @@ public class FillZeitreihePdfBeanService {
 
         final ZeitauswahlDTO zeitauswahlDTO = zeitauswahlService.determinePossibleZeitauswahl(zaehlung.getZaehldauer(), zaehlung.getId());
 
-        processZaehldatenZeitreiheService.getFilteredAndSortedZaehlungenForZeitreihe(zaehlstelle, zaehlung, options, zeitauswahlDTO)
+        processZaehldatenZeitreiheService.getFilteredAndSortedZaehlungenForZeitreihe(zaehlstelle, zaehlung, options)
                 .filter(zaehlungForComment -> StringUtils.isNotEmpty(zaehlungForComment.getKommentar()))
                 .forEach(zaehlungForComment -> {
                     final ZusatzinformationenZeitreihePdfComponent zusatzinformationenZeitreihe = new ZusatzinformationenZeitreihePdfComponent();

--- a/src/main/java/de/muenchen/dave/services/processzaehldaten/ProcessZaehldatenZeitreiheService.java
+++ b/src/main/java/de/muenchen/dave/services/processzaehldaten/ProcessZaehldatenZeitreiheService.java
@@ -57,7 +57,7 @@ public class ProcessZaehldatenZeitreiheService {
      * @param options Optionen aus dem Frontend
      * @return true, wenn Check erfolgreich, sonst false
      */
-    private static boolean checkVerkehrsbeziehungen(final Zaehlung zaehlung, final OptionsDTO options) {
+    static boolean checkVerkehrsbeziehungen(final Zaehlung zaehlung, final OptionsDTO options) {
 
         // Bei QU: Prüfe auf Knotenarm und Richtung
         if (zaehlung.getZaehlart().equals(Zaehlart.QU.toString())) {

--- a/src/main/java/de/muenchen/dave/services/processzaehldaten/ProcessZaehldatenZeitreiheService.java
+++ b/src/main/java/de/muenchen/dave/services/processzaehldaten/ProcessZaehldatenZeitreiheService.java
@@ -49,15 +49,15 @@ public class ProcessZaehldatenZeitreiheService {
 
     /**
      * Hier wird überprüft, ob die mitgegebene Zählung die in den mitgegebenen Optionen ausgewählte
-     * Verkehrsbeziehung besitzt.
-     * Für die Zählarten QU, FJS, QJS gilt: alle Verkehrsbeziehungen und Pfeile, die in den Optionen
+     * Bewegungsbeziehung besitzt.
+     * Für die Zählarten QU, FJS, QJS gilt: alle Bewegungsbeziehungen/Pfeile, die in den Optionen
      * gewählt sind, müssen in der Zaehlung vorhanden sein.
      *
      * @param zaehlung Zählung die überprüft werden soll
      * @param options Optionen aus dem Frontend
      * @return true, wenn Check erfolgreich, sonst false
      */
-    static boolean checkVerkehrsbeziehungen(final Zaehlung zaehlung, final OptionsDTO options) {
+    static boolean checkBewegungsbeziehung(final Zaehlung zaehlung, final OptionsDTO options) {
 
         // Bei QU: Prüfe auf Knotenarm und Richtung
         if (zaehlung.getZaehlart().equals(Zaehlart.QU.toString())) {
@@ -224,12 +224,12 @@ public class ProcessZaehldatenZeitreiheService {
 
         final LadeZaehldatenZeitreiheDTO ladeZaehldatenZeitreihe = new LadeZaehldatenZeitreiheDTO();
 
-        final ZeitauswahlDTO zeitauswahlDTO = zeitauswahlService.determinePossibleZeitauswahl(currentZaehlung.getZaehldauer(), currentZaehlung.getId());
+        //final ZeitauswahlDTO zeitauswahlDTO = zeitauswahlService.determinePossibleZeitauswahl(currentZaehlung.getZaehldauer(), currentZaehlung.getId());
 
-        getFilteredAndSortedZaehlungenForZeitreihe(zaehlstelle, currentZaehlung, options, zeitauswahlDTO)
+        getFilteredAndSortedZaehlungenForZeitreihe(zaehlstelle, currentZaehlung, options)
                 .forEach(zaehlung -> {
                     List<Zeitintervall> zeitintervalle = List.of();
-                    if (checkVerkehrsbeziehungen(zaehlung, options)) {
+                    if (checkBewegungsbeziehung(zaehlung, options)) {
                         // Setzen der Zähldauer anhand der aktuellen Zählung nötig, da es ansonsten zu einem Fehler kommt wenn die Basiszählung,
                         // auf der die Optionen basieren, eine 24-Std.-Zählung ist, diese allerdings mit 2x4-Std.-Zählungen verglichen wird
                         options.setZaehldauer(Zaehldauer.valueOf(zaehlung.getZaehldauer()));
@@ -285,13 +285,11 @@ public class ProcessZaehldatenZeitreiheService {
      * @param zaehlstelle Zählstelle mit allen Zählungen
      * @param currentZaehlung Im Frontend ausgewählten Zählung
      * @param options Optionen aus dem Frontend
-     * @param zeitauswahlDTO ZeitauswahlDTO um für Vergleich von Zeitblock in Zählung
      * @return Stream der gefilterten Zählungen
      */
     public Stream<Zaehlung> getFilteredAndSortedZaehlungenForZeitreihe(final Zaehlstelle zaehlstelle,
             final Zaehlung currentZaehlung,
-            final OptionsDTO options,
-            final ZeitauswahlDTO zeitauswahlDTO) {
+            final OptionsDTO options) {
         final LocalDate currentDate = currentZaehlung.getDatum();
         final LocalDate oldestDateToSearchFor = calculateOldestDate(zaehlstelle, currentDate, options);
 

--- a/src/main/java/de/muenchen/dave/services/processzaehldaten/ProcessZaehldatenZeitreiheService.java
+++ b/src/main/java/de/muenchen/dave/services/processzaehldaten/ProcessZaehldatenZeitreiheService.java
@@ -50,34 +50,37 @@ public class ProcessZaehldatenZeitreiheService {
     /**
      * Hier wird überprüft, ob die mitgegebene Zählung die in den mitgegebenen Optionen ausgewählte
      * Bewegungsbeziehung besitzt.
-     * Für die Zählarten QU, FJS, QJS gilt: alle Bewegungsbeziehungen/Pfeile, die in den Optionen
-     * gewählt sind, müssen in der Zaehlung vorhanden sein.
+     * Für die Zählarten QU, FJS, QJS gilt: alle Bewegungsbeziehungen/Pfeile müssen mit der aktiven Zaehlung übereinstimmen.
      *
      * @param zaehlung Zählung die überprüft werden soll
      * @param options Optionen aus dem Frontend
+     * @param currentZaehlung die aktuelle Zählung
      * @return true, wenn Check erfolgreich, sonst false
      */
-    static boolean checkBewegungsbeziehung(final Zaehlung zaehlung, final OptionsDTO options) {
+    static boolean checkBewegungsbeziehung(final Zaehlung zaehlung, final OptionsDTO options, final Zaehlung currentZaehlung) {
 
         // Bei QU: Prüfe auf Knotenarm und Richtung
         if (zaehlung.getZaehlart().equals(Zaehlart.QU.toString())) {
-            return options.getChosenQuerungsverkehre().stream()
-                    .allMatch(opt -> zaehlung.getQuerungsverkehr().stream()
-                            .anyMatch(qv -> Objects.equals(qv.getKnotenarm(), opt.getKnotenarm()) &&
-                                    Objects.equals(qv.getRichtung(), opt.getRichtung())));
+            return currentZaehlung.getQuerungsverkehr().size() == zaehlung.getQuerungsverkehr().size() &&
+                    currentZaehlung.getQuerungsverkehr().stream()
+                    .allMatch(current -> zaehlung.getQuerungsverkehr().stream()
+                            .anyMatch(qv -> Objects.equals(qv.getKnotenarm(), current.getKnotenarm()) &&
+                                    Objects.equals(qv.getRichtung(), current.getRichtung())));
         }
         // Bei FJS: Prüfe auf Knotenarm, Richtung und Straßenseite
         if (zaehlung.getZaehlart().equals(Zaehlart.FJS.toString())) {
-            return options.getChosenLaengsverkehre().stream()
-                    .allMatch(opt -> zaehlung.getLaengsverkehr().stream()
-                            .anyMatch(lv -> Objects.equals(lv.getKnotenarm(), opt.getKnotenarm()) &&
-                                    Objects.equals(lv.getRichtung(), opt.getRichtung()) &&
-                                    Objects.equals(lv.getStrassenseite(), opt.getStrassenseite())));
+            return currentZaehlung.getLaengsverkehr().size() == zaehlung.getLaengsverkehr().size() &&
+                    currentZaehlung.getLaengsverkehr().stream()
+                    .allMatch(current -> zaehlung.getLaengsverkehr().stream()
+                            .anyMatch(lv -> Objects.equals(lv.getKnotenarm(), current.getKnotenarm()) &&
+                                    Objects.equals(lv.getRichtung(), current.getRichtung()) &&
+                                    Objects.equals(lv.getStrassenseite(), current.getStrassenseite())));
         }
 
         // Bei QJS: Prüfe auf Von, Nach und Straßenseite
         if (zaehlung.getZaehlart().equals(Zaehlart.QJS.toString())) {
-            return options.getChosenVerkehrsbeziehungen().stream()
+            return currentZaehlung.getVerkehrsbeziehungen().size() == zaehlung.getVerkehrsbeziehungen().size() &&
+                    currentZaehlung.getVerkehrsbeziehungen().stream()
                     .allMatch(opt -> zaehlung.getVerkehrsbeziehungen().stream()
                             .anyMatch(vb -> Objects.equals(vb.getVon(), opt.getVon()) &&
                                     Objects.equals(vb.getNach(), opt.getNach()) &&
@@ -229,7 +232,7 @@ public class ProcessZaehldatenZeitreiheService {
         getFilteredAndSortedZaehlungenForZeitreihe(zaehlstelle, currentZaehlung, options)
                 .forEach(zaehlung -> {
                     List<Zeitintervall> zeitintervalle = List.of();
-                    if (checkBewegungsbeziehung(zaehlung, options)) {
+                    if (checkBewegungsbeziehung(zaehlung, options, currentZaehlung)) {
                         // Setzen der Zähldauer anhand der aktuellen Zählung nötig, da es ansonsten zu einem Fehler kommt wenn die Basiszählung,
                         // auf der die Optionen basieren, eine 24-Std.-Zählung ist, diese allerdings mit 2x4-Std.-Zählungen verglichen wird
                         options.setZaehldauer(Zaehldauer.valueOf(zaehlung.getZaehldauer()));

--- a/src/main/java/de/muenchen/dave/services/processzaehldaten/ProcessZaehldatenZeitreiheService.java
+++ b/src/main/java/de/muenchen/dave/services/processzaehldaten/ProcessZaehldatenZeitreiheService.java
@@ -49,11 +49,13 @@ public class ProcessZaehldatenZeitreiheService {
 
     /**
      * Hier wird überprüft, ob die mitgegebene Zählung die in den mitgegebenen Optionen ausgewählte
-     * Verkehrsbeziehung besitzt
+     * Verkehrsbeziehung besitzt.
+     * Für die Zählarten QU, FJS, QJS gilt: alle Verkehrsbeziehungen und Pfeile, die in den Optionen
+     * gewählt sind, müssen in der Zaehlung vorhanden sein.
      *
      * @param zaehlung Zählung die überprüft werden soll
-     * @param options
-     * @return
+     * @param options Optionen aus dem Frontend
+     * @return true, wenn Check erfolgreich, sonst false
      */
     private static boolean checkVerkehrsbeziehungen(final Zaehlung zaehlung, final OptionsDTO options) {
 

--- a/src/main/java/de/muenchen/dave/services/processzaehldaten/ProcessZaehldatenZeitreiheService.java
+++ b/src/main/java/de/muenchen/dave/services/processzaehldaten/ProcessZaehldatenZeitreiheService.java
@@ -5,7 +5,6 @@ import de.muenchen.dave.domain.Zeitintervall;
 import de.muenchen.dave.domain.dtos.OptionsDTO;
 import de.muenchen.dave.domain.dtos.laden.LadeZaehldatenZeitreiheDTO;
 import de.muenchen.dave.domain.dtos.laden.LadeZaehldatumDTO;
-import de.muenchen.dave.domain.dtos.laden.ZeitauswahlDTO;
 import de.muenchen.dave.domain.elasticsearch.Verkehrsbeziehung;
 import de.muenchen.dave.domain.elasticsearch.Zaehlstelle;
 import de.muenchen.dave.domain.elasticsearch.Zaehlung;
@@ -50,7 +49,8 @@ public class ProcessZaehldatenZeitreiheService {
     /**
      * Hier wird überprüft, ob die mitgegebene Zählung die in den mitgegebenen Optionen ausgewählte
      * Bewegungsbeziehung besitzt.
-     * Für die Zählarten QU, FJS, QJS gilt: alle Bewegungsbeziehungen/Pfeile müssen mit der aktiven Zaehlung übereinstimmen.
+     * Für die Zählarten QU, FJS, QJS gilt: alle Bewegungsbeziehungen/Pfeile müssen mit der aktiven
+     * Zaehlung übereinstimmen.
      *
      * @param zaehlung Zählung die überprüft werden soll
      * @param options Optionen aus dem Frontend
@@ -63,28 +63,28 @@ public class ProcessZaehldatenZeitreiheService {
         if (zaehlung.getZaehlart().equals(Zaehlart.QU.toString())) {
             return currentZaehlung.getQuerungsverkehr().size() == zaehlung.getQuerungsverkehr().size() &&
                     currentZaehlung.getQuerungsverkehr().stream()
-                    .allMatch(current -> zaehlung.getQuerungsverkehr().stream()
-                            .anyMatch(qv -> Objects.equals(qv.getKnotenarm(), current.getKnotenarm()) &&
-                                    Objects.equals(qv.getRichtung(), current.getRichtung())));
+                            .allMatch(current -> zaehlung.getQuerungsverkehr().stream()
+                                    .anyMatch(qv -> Objects.equals(qv.getKnotenarm(), current.getKnotenarm()) &&
+                                            Objects.equals(qv.getRichtung(), current.getRichtung())));
         }
         // Bei FJS: Prüfe auf Knotenarm, Richtung und Straßenseite
         if (zaehlung.getZaehlart().equals(Zaehlart.FJS.toString())) {
             return currentZaehlung.getLaengsverkehr().size() == zaehlung.getLaengsverkehr().size() &&
                     currentZaehlung.getLaengsverkehr().stream()
-                    .allMatch(current -> zaehlung.getLaengsverkehr().stream()
-                            .anyMatch(lv -> Objects.equals(lv.getKnotenarm(), current.getKnotenarm()) &&
-                                    Objects.equals(lv.getRichtung(), current.getRichtung()) &&
-                                    Objects.equals(lv.getStrassenseite(), current.getStrassenseite())));
+                            .allMatch(current -> zaehlung.getLaengsverkehr().stream()
+                                    .anyMatch(lv -> Objects.equals(lv.getKnotenarm(), current.getKnotenarm()) &&
+                                            Objects.equals(lv.getRichtung(), current.getRichtung()) &&
+                                            Objects.equals(lv.getStrassenseite(), current.getStrassenseite())));
         }
 
         // Bei QJS: Prüfe auf Von, Nach und Straßenseite
         if (zaehlung.getZaehlart().equals(Zaehlart.QJS.toString())) {
             return currentZaehlung.getVerkehrsbeziehungen().size() == zaehlung.getVerkehrsbeziehungen().size() &&
                     currentZaehlung.getVerkehrsbeziehungen().stream()
-                    .allMatch(opt -> zaehlung.getVerkehrsbeziehungen().stream()
-                            .anyMatch(vb -> Objects.equals(vb.getVon(), opt.getVon()) &&
-                                    Objects.equals(vb.getNach(), opt.getNach()) &&
-                                    Objects.equals(vb.getStrassenseite(), opt.getStrassenseite())));
+                            .allMatch(opt -> zaehlung.getVerkehrsbeziehungen().stream()
+                                    .anyMatch(vb -> Objects.equals(vb.getVon(), opt.getVon()) &&
+                                            Objects.equals(vb.getNach(), opt.getNach()) &&
+                                            Objects.equals(vb.getStrassenseite(), opt.getStrassenseite())));
         }
 
         final List<Verkehrsbeziehung> verkehrsbeziehungList;

--- a/src/main/java/de/muenchen/dave/services/processzaehldaten/ProcessZaehldatenZeitreiheService.java
+++ b/src/main/java/de/muenchen/dave/services/processzaehldaten/ProcessZaehldatenZeitreiheService.java
@@ -258,19 +258,22 @@ public class ProcessZaehldatenZeitreiheService {
                         ladeZaehldatenZeitreihe.getDatum().add(zaehlung.getDatum().format(FillPdfBeanService.DDMMYYYY));
 
                         fillLadeZaehldatenZeitreiheDTO(options, ladeZaehldatenZeitreihe, ladeZaehldatum);
-                    } else {
-                        final var ladeZaehldatum = new LadeZaehldatumDTO();
-                        ladeZaehldatum.setPkw(0);
-                        ladeZaehldatum.setLkw(0);
-                        ladeZaehldatum.setLastzuege(0);
-                        ladeZaehldatum.setBusse(0);
-                        ladeZaehldatum.setKraftraeder(0);
-                        ladeZaehldatum.setFahrradfahrer(0);
-                        ladeZaehldatum.setFussgaenger(0);
-                        ladeZaehldatum.setPkwEinheiten(0);
+                    }
+                    else {
+                        if (!List.of(Zaehlart.QU.toString(), Zaehlart.FJS.toString(), Zaehlart.QJS.toString()).contains(zaehlung.getZaehlart())) {
+                            final var ladeZaehldatum = new LadeZaehldatumDTO();
+                            ladeZaehldatum.setPkw(0);
+                            ladeZaehldatum.setLkw(0);
+                            ladeZaehldatum.setLastzuege(0);
+                            ladeZaehldatum.setBusse(0);
+                            ladeZaehldatum.setKraftraeder(0);
+                            ladeZaehldatum.setFahrradfahrer(0);
+                            ladeZaehldatum.setFussgaenger(0);
+                            ladeZaehldatum.setPkwEinheiten(0);
 
-                        ladeZaehldatenZeitreihe.getDatum().add(zaehlung.getDatum().format(FillPdfBeanService.DDMMYYYY) + VERKEHRSBEZIEHUNG_NICHT_VORHANDEN);
-                        fillLadeZaehldatenZeitreiheDTO(options, ladeZaehldatenZeitreihe, ladeZaehldatum);
+                            ladeZaehldatenZeitreihe.getDatum().add(zaehlung.getDatum().format(FillPdfBeanService.DDMMYYYY) + VERKEHRSBEZIEHUNG_NICHT_VORHANDEN);
+                            fillLadeZaehldatenZeitreiheDTO(options, ladeZaehldatenZeitreihe, ladeZaehldatum);
+                        }
                     }
                 });
         return ladeZaehldatenZeitreihe;

--- a/src/main/java/de/muenchen/dave/services/processzaehldaten/ProcessZaehldatenZeitreiheService.java
+++ b/src/main/java/de/muenchen/dave/services/processzaehldaten/ProcessZaehldatenZeitreiheService.java
@@ -25,6 +25,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
@@ -55,6 +56,41 @@ public class ProcessZaehldatenZeitreiheService {
      * @return
      */
     private static boolean checkVerkehrsbeziehungen(final Zaehlung zaehlung, final OptionsDTO options) {
+
+        // Bei QU: Prüfe auf Knotenarm und Richtung
+        if (zaehlung.getZaehlart().equals(Zaehlart.QU.toString())) {
+            return options.getChosenQuerungsverkehre().stream()
+                    .allMatch(opt -> zaehlung.getQuerungsverkehr().stream()
+                            .anyMatch(qv ->
+                                    Objects.equals(qv.getKnotenarm(), opt.getKnotenarm()) &&
+                                            Objects.equals(qv.getRichtung(), opt.getRichtung())
+                            )
+                    );
+        }
+        // Bei FJS: Prüfe auf Knotenarm, Richtung und Straßenseite
+        if (zaehlung.getZaehlart().equals(Zaehlart.FJS.toString())) {
+            return options.getChosenLaengsverkehre().stream()
+                    .allMatch(opt -> zaehlung.getLaengsverkehr().stream()
+                            .anyMatch(lv ->
+                                    Objects.equals(lv.getKnotenarm(), opt.getKnotenarm()) &&
+                                    Objects.equals(lv.getRichtung(), opt.getRichtung()) &&
+                                    Objects.equals(lv.getStrassenseite(), opt.getStrassenseite())
+                            )
+                    );
+        }
+
+        // Bei QJS: Prüfe auf Von, Nach und Straßenseite
+        if (zaehlung.getZaehlart().equals(Zaehlart.QJS.toString())) {
+            return options.getChosenVerkehrsbeziehungen().stream()
+                    .allMatch(opt -> zaehlung.getVerkehrsbeziehungen().stream()
+                            .anyMatch(vb ->
+                                    Objects.equals(vb.getVon(), opt.getVon()) &&
+                                    Objects.equals(vb.getNach(), opt.getNach()) &&
+                                    Objects.equals(vb.getStrassenseite(), opt.getStrassenseite())
+                            )
+                    );
+        }
+
         final List<Verkehrsbeziehung> verkehrsbeziehungList;
         if (zaehlung.getKreisverkehr()) {
             // Bei Kreisverkehr: Prüfe auf Knotenarm

--- a/src/main/java/de/muenchen/dave/services/processzaehldaten/ProcessZaehldatenZeitreiheService.java
+++ b/src/main/java/de/muenchen/dave/services/processzaehldaten/ProcessZaehldatenZeitreiheService.java
@@ -23,9 +23,9 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
-import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
@@ -61,34 +61,25 @@ public class ProcessZaehldatenZeitreiheService {
         if (zaehlung.getZaehlart().equals(Zaehlart.QU.toString())) {
             return options.getChosenQuerungsverkehre().stream()
                     .allMatch(opt -> zaehlung.getQuerungsverkehr().stream()
-                            .anyMatch(qv ->
-                                    Objects.equals(qv.getKnotenarm(), opt.getKnotenarm()) &&
-                                            Objects.equals(qv.getRichtung(), opt.getRichtung())
-                            )
-                    );
+                            .anyMatch(qv -> Objects.equals(qv.getKnotenarm(), opt.getKnotenarm()) &&
+                                    Objects.equals(qv.getRichtung(), opt.getRichtung())));
         }
         // Bei FJS: Prüfe auf Knotenarm, Richtung und Straßenseite
         if (zaehlung.getZaehlart().equals(Zaehlart.FJS.toString())) {
             return options.getChosenLaengsverkehre().stream()
                     .allMatch(opt -> zaehlung.getLaengsverkehr().stream()
-                            .anyMatch(lv ->
-                                    Objects.equals(lv.getKnotenarm(), opt.getKnotenarm()) &&
+                            .anyMatch(lv -> Objects.equals(lv.getKnotenarm(), opt.getKnotenarm()) &&
                                     Objects.equals(lv.getRichtung(), opt.getRichtung()) &&
-                                    Objects.equals(lv.getStrassenseite(), opt.getStrassenseite())
-                            )
-                    );
+                                    Objects.equals(lv.getStrassenseite(), opt.getStrassenseite())));
         }
 
         // Bei QJS: Prüfe auf Von, Nach und Straßenseite
         if (zaehlung.getZaehlart().equals(Zaehlart.QJS.toString())) {
             return options.getChosenVerkehrsbeziehungen().stream()
                     .allMatch(opt -> zaehlung.getVerkehrsbeziehungen().stream()
-                            .anyMatch(vb ->
-                                    Objects.equals(vb.getVon(), opt.getVon()) &&
+                            .anyMatch(vb -> Objects.equals(vb.getVon(), opt.getVon()) &&
                                     Objects.equals(vb.getNach(), opt.getNach()) &&
-                                    Objects.equals(vb.getStrassenseite(), opt.getStrassenseite())
-                            )
-                    );
+                                    Objects.equals(vb.getStrassenseite(), opt.getStrassenseite())));
         }
 
         final List<Verkehrsbeziehung> verkehrsbeziehungList;
@@ -258,8 +249,7 @@ public class ProcessZaehldatenZeitreiheService {
                         ladeZaehldatenZeitreihe.getDatum().add(zaehlung.getDatum().format(FillPdfBeanService.DDMMYYYY));
 
                         fillLadeZaehldatenZeitreiheDTO(options, ladeZaehldatenZeitreihe, ladeZaehldatum);
-                    }
-                    else {
+                    } else {
                         if (!List.of(Zaehlart.QU.toString(), Zaehlart.FJS.toString(), Zaehlart.QJS.toString()).contains(zaehlung.getZaehlart())) {
                             final var ladeZaehldatum = new LadeZaehldatumDTO();
                             ladeZaehldatum.setPkw(0);

--- a/src/test/java/de/muenchen/dave/services/processzaehldaten/ProcessZaehldatenZeitreiheTest.java
+++ b/src/test/java/de/muenchen/dave/services/processzaehldaten/ProcessZaehldatenZeitreiheTest.java
@@ -207,6 +207,14 @@ public class ProcessZaehldatenZeitreiheTest {
             }
         }));
         assertThat(ProcessZaehldatenZeitreiheService.checkVerkehrsbeziehungen(zaehlung, options), is(false));
+
+        options.setChosenQuerungsverkehre(List.of(new OptionsQuerungsverkehrDTO() {
+            {
+                setKnotenarm(1);
+                setRichtung(Himmelsrichtung.W);
+            }
+        }));
+        assertThat(ProcessZaehldatenZeitreiheService.checkVerkehrsbeziehungen(zaehlung, options), is(false));
     }
 
     @Test
@@ -221,7 +229,7 @@ public class ProcessZaehldatenZeitreiheTest {
         Laengsverkehr l2 = new Laengsverkehr();
         l2.setKnotenarm(1);
         l2.setRichtung(Bewegungsrichtung.AUS);
-        l2.setStrassenseite(Himmelsrichtung.N);
+        l2.setStrassenseite(Himmelsrichtung.S);
         zaehlung.setLaengsverkehr(List.of(l1, l2));
 
         // positive cases
@@ -245,7 +253,7 @@ public class ProcessZaehldatenZeitreiheTest {
             {
                 setKnotenarm(1);
                 setRichtung(Bewegungsrichtung.AUS);
-                setStrassenseite(Himmelsrichtung.N);
+                setStrassenseite(Himmelsrichtung.S);
             }
         }));
         assertThat(ProcessZaehldatenZeitreiheService.checkVerkehrsbeziehungen(zaehlung, options), is(true));
@@ -264,7 +272,7 @@ public class ProcessZaehldatenZeitreiheTest {
             {
                 setKnotenarm(1);
                 setRichtung(Bewegungsrichtung.AUS);
-                setStrassenseite(Himmelsrichtung.S);
+                setStrassenseite(Himmelsrichtung.N);
             }
         }));
         assertThat(ProcessZaehldatenZeitreiheService.checkVerkehrsbeziehungen(zaehlung, options), is(false));
@@ -277,6 +285,7 @@ public class ProcessZaehldatenZeitreiheTest {
             }
         }));
         assertThat(ProcessZaehldatenZeitreiheService.checkVerkehrsbeziehungen(zaehlung, options), is(false));
+
     }
 
     @Test
@@ -326,6 +335,24 @@ public class ProcessZaehldatenZeitreiheTest {
                 setVon(1);
                 setNach(3);
                 setStrassenseite(Himmelsrichtung.S);
+            }
+        }));
+        assertThat(ProcessZaehldatenZeitreiheService.checkVerkehrsbeziehungen(zaehlung, options), is(false));
+
+        options.setChosenVerkehrsbeziehungen(List.of(new OptionsVerkehrsbeziehungDTO() {
+            {
+                setVon(3);
+                setNach(3);
+                setStrassenseite(Himmelsrichtung.N);
+            }
+        }));
+        assertThat(ProcessZaehldatenZeitreiheService.checkVerkehrsbeziehungen(zaehlung, options), is(false));
+
+        options.setChosenVerkehrsbeziehungen(List.of(new OptionsVerkehrsbeziehungDTO() {
+            {
+                setVon(1);
+                setNach(1);
+                setStrassenseite(Himmelsrichtung.N);
             }
         }));
         assertThat(ProcessZaehldatenZeitreiheService.checkVerkehrsbeziehungen(zaehlung, options), is(false));

--- a/src/test/java/de/muenchen/dave/services/processzaehldaten/ProcessZaehldatenZeitreiheTest.java
+++ b/src/test/java/de/muenchen/dave/services/processzaehldaten/ProcessZaehldatenZeitreiheTest.java
@@ -4,9 +4,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 import de.muenchen.dave.domain.dtos.OptionsDTO;
-import de.muenchen.dave.domain.dtos.OptionsLaengsverkehrDTO;
-import de.muenchen.dave.domain.dtos.OptionsQuerungsverkehrDTO;
-import de.muenchen.dave.domain.dtos.OptionsVerkehrsbeziehungDTO;
 import de.muenchen.dave.domain.dtos.laden.LadeZaehldatenZeitreiheDTO;
 import de.muenchen.dave.domain.dtos.laden.LadeZaehldatumDTO;
 import de.muenchen.dave.domain.elasticsearch.*;

--- a/src/test/java/de/muenchen/dave/services/processzaehldaten/ProcessZaehldatenZeitreiheTest.java
+++ b/src/test/java/de/muenchen/dave/services/processzaehldaten/ProcessZaehldatenZeitreiheTest.java
@@ -170,7 +170,7 @@ public class ProcessZaehldatenZeitreiheTest {
                 setRichtung(Himmelsrichtung.N);
             }
         }));
-        assertThat(ProcessZaehldatenZeitreiheService.checkVerkehrsbeziehungen(zaehlung, options), is(true));
+        assertThat(ProcessZaehldatenZeitreiheService.checkBewegungsbeziehung(zaehlung, options), is(true));
 
         options.setChosenQuerungsverkehre(List.of(new OptionsQuerungsverkehrDTO() {
             {
@@ -183,7 +183,7 @@ public class ProcessZaehldatenZeitreiheTest {
                 setRichtung(Himmelsrichtung.S);
             }
         }));
-        assertThat(ProcessZaehldatenZeitreiheService.checkVerkehrsbeziehungen(zaehlung, options), is(true));
+        assertThat(ProcessZaehldatenZeitreiheService.checkBewegungsbeziehung(zaehlung, options), is(true));
 
         // negative cases
         options.setChosenQuerungsverkehre(List.of(new OptionsQuerungsverkehrDTO() {
@@ -192,7 +192,7 @@ public class ProcessZaehldatenZeitreiheTest {
                 setRichtung(Himmelsrichtung.N);
             }
         }));
-        assertThat(ProcessZaehldatenZeitreiheService.checkVerkehrsbeziehungen(zaehlung, options), is(false));
+        assertThat(ProcessZaehldatenZeitreiheService.checkBewegungsbeziehung(zaehlung, options), is(false));
 
         // negative cases
         options.setChosenQuerungsverkehre(List.of(new OptionsQuerungsverkehrDTO() {
@@ -206,7 +206,7 @@ public class ProcessZaehldatenZeitreiheTest {
                 setRichtung(Himmelsrichtung.S);
             }
         }));
-        assertThat(ProcessZaehldatenZeitreiheService.checkVerkehrsbeziehungen(zaehlung, options), is(false));
+        assertThat(ProcessZaehldatenZeitreiheService.checkBewegungsbeziehung(zaehlung, options), is(false));
 
         options.setChosenQuerungsverkehre(List.of(new OptionsQuerungsverkehrDTO() {
             {
@@ -214,7 +214,7 @@ public class ProcessZaehldatenZeitreiheTest {
                 setRichtung(Himmelsrichtung.W);
             }
         }));
-        assertThat(ProcessZaehldatenZeitreiheService.checkVerkehrsbeziehungen(zaehlung, options), is(false));
+        assertThat(ProcessZaehldatenZeitreiheService.checkBewegungsbeziehung(zaehlung, options), is(false));
     }
 
     @Test
@@ -241,7 +241,7 @@ public class ProcessZaehldatenZeitreiheTest {
                 setStrassenseite(Himmelsrichtung.N);
             }
         }));
-        assertThat(ProcessZaehldatenZeitreiheService.checkVerkehrsbeziehungen(zaehlung, options), is(true));
+        assertThat(ProcessZaehldatenZeitreiheService.checkBewegungsbeziehung(zaehlung, options), is(true));
 
         options.setChosenLaengsverkehre(List.of(new OptionsLaengsverkehrDTO() {
             {
@@ -256,7 +256,7 @@ public class ProcessZaehldatenZeitreiheTest {
                 setStrassenseite(Himmelsrichtung.S);
             }
         }));
-        assertThat(ProcessZaehldatenZeitreiheService.checkVerkehrsbeziehungen(zaehlung, options), is(true));
+        assertThat(ProcessZaehldatenZeitreiheService.checkBewegungsbeziehung(zaehlung, options), is(true));
 
         // negative cases
         options.setChosenLaengsverkehre(List.of(new OptionsLaengsverkehrDTO() {
@@ -266,7 +266,7 @@ public class ProcessZaehldatenZeitreiheTest {
                 setStrassenseite(Himmelsrichtung.N);
             }
         }));
-        assertThat(ProcessZaehldatenZeitreiheService.checkVerkehrsbeziehungen(zaehlung, options), is(false));
+        assertThat(ProcessZaehldatenZeitreiheService.checkBewegungsbeziehung(zaehlung, options), is(false));
 
         options.setChosenLaengsverkehre(List.of(new OptionsLaengsverkehrDTO() {
             {
@@ -275,7 +275,7 @@ public class ProcessZaehldatenZeitreiheTest {
                 setStrassenseite(Himmelsrichtung.N);
             }
         }));
-        assertThat(ProcessZaehldatenZeitreiheService.checkVerkehrsbeziehungen(zaehlung, options), is(false));
+        assertThat(ProcessZaehldatenZeitreiheService.checkBewegungsbeziehung(zaehlung, options), is(false));
 
         options.setChosenLaengsverkehre(List.of(new OptionsLaengsverkehrDTO() {
             {
@@ -284,7 +284,7 @@ public class ProcessZaehldatenZeitreiheTest {
                 setStrassenseite(Himmelsrichtung.S);
             }
         }));
-        assertThat(ProcessZaehldatenZeitreiheService.checkVerkehrsbeziehungen(zaehlung, options), is(false));
+        assertThat(ProcessZaehldatenZeitreiheService.checkBewegungsbeziehung(zaehlung, options), is(false));
 
     }
 
@@ -312,7 +312,7 @@ public class ProcessZaehldatenZeitreiheTest {
                 setStrassenseite(Himmelsrichtung.N);
             }
         }));
-        assertThat(ProcessZaehldatenZeitreiheService.checkVerkehrsbeziehungen(zaehlung, options), is(true));
+        assertThat(ProcessZaehldatenZeitreiheService.checkBewegungsbeziehung(zaehlung, options), is(true));
 
         options.setChosenVerkehrsbeziehungen(List.of(new OptionsVerkehrsbeziehungDTO() {
             {
@@ -327,7 +327,7 @@ public class ProcessZaehldatenZeitreiheTest {
                 setStrassenseite(Himmelsrichtung.N);
             }
         }));
-        assertThat(ProcessZaehldatenZeitreiheService.checkVerkehrsbeziehungen(zaehlung, options), is(true));
+        assertThat(ProcessZaehldatenZeitreiheService.checkBewegungsbeziehung(zaehlung, options), is(true));
 
         // negative cases
         options.setChosenVerkehrsbeziehungen(List.of(new OptionsVerkehrsbeziehungDTO() {
@@ -337,7 +337,7 @@ public class ProcessZaehldatenZeitreiheTest {
                 setStrassenseite(Himmelsrichtung.S);
             }
         }));
-        assertThat(ProcessZaehldatenZeitreiheService.checkVerkehrsbeziehungen(zaehlung, options), is(false));
+        assertThat(ProcessZaehldatenZeitreiheService.checkBewegungsbeziehung(zaehlung, options), is(false));
 
         options.setChosenVerkehrsbeziehungen(List.of(new OptionsVerkehrsbeziehungDTO() {
             {
@@ -346,7 +346,7 @@ public class ProcessZaehldatenZeitreiheTest {
                 setStrassenseite(Himmelsrichtung.N);
             }
         }));
-        assertThat(ProcessZaehldatenZeitreiheService.checkVerkehrsbeziehungen(zaehlung, options), is(false));
+        assertThat(ProcessZaehldatenZeitreiheService.checkBewegungsbeziehung(zaehlung, options), is(false));
 
         options.setChosenVerkehrsbeziehungen(List.of(new OptionsVerkehrsbeziehungDTO() {
             {
@@ -355,6 +355,6 @@ public class ProcessZaehldatenZeitreiheTest {
                 setStrassenseite(Himmelsrichtung.N);
             }
         }));
-        assertThat(ProcessZaehldatenZeitreiheService.checkVerkehrsbeziehungen(zaehlung, options), is(false));
+        assertThat(ProcessZaehldatenZeitreiheService.checkBewegungsbeziehung(zaehlung, options), is(false));
     }
 }

--- a/src/test/java/de/muenchen/dave/services/processzaehldaten/ProcessZaehldatenZeitreiheTest.java
+++ b/src/test/java/de/muenchen/dave/services/processzaehldaten/ProcessZaehldatenZeitreiheTest.java
@@ -150,7 +150,7 @@ public class ProcessZaehldatenZeitreiheTest {
     }
 
     @Test
-    public void checkVerkehrsbeziehungenQU() {
+    public void checkBewegungsbeziehungenQU() {
         // setup
         Zaehlung zaehlung = new Zaehlung();
         zaehlung.setZaehlart(Zaehlart.QU.name());
@@ -162,63 +162,43 @@ public class ProcessZaehldatenZeitreiheTest {
         qv2.setRichtung(Himmelsrichtung.S);
         zaehlung.setQuerungsverkehr(List.of(qv1, qv2));
 
-        // positive cases
-        OptionsDTO options = new OptionsDTO();
-        options.setChosenQuerungsverkehre(List.of(new OptionsQuerungsverkehrDTO() {
-            {
-                setKnotenarm(1);
-                setRichtung(Himmelsrichtung.N);
-            }
-        }));
-        assertThat(ProcessZaehldatenZeitreiheService.checkBewegungsbeziehung(zaehlung, options), is(true));
-
-        options.setChosenQuerungsverkehre(List.of(new OptionsQuerungsverkehrDTO() {
-            {
-                setKnotenarm(1);
-                setRichtung(Himmelsrichtung.N);
-            }
-        }, new OptionsQuerungsverkehrDTO() {
-            {
-                setKnotenarm(1);
-                setRichtung(Himmelsrichtung.S);
-            }
-        }));
-        assertThat(ProcessZaehldatenZeitreiheService.checkBewegungsbeziehung(zaehlung, options), is(true));
+        // positive case
+        Zaehlung matchingZaehlung = new Zaehlung();
+        matchingZaehlung.setZaehlart(Zaehlart.QU.name());
+        matchingZaehlung.setQuerungsverkehr(List.of(qv1, qv2));
+        assertThat(ProcessZaehldatenZeitreiheService.checkBewegungsbeziehung(zaehlung, new OptionsDTO(), matchingZaehlung), is(true));
 
         // negative cases
-        options.setChosenQuerungsverkehre(List.of(new OptionsQuerungsverkehrDTO() {
-            {
-                setKnotenarm(2);
-                setRichtung(Himmelsrichtung.N);
-            }
-        }));
-        assertThat(ProcessZaehldatenZeitreiheService.checkBewegungsbeziehung(zaehlung, options), is(false));
+        Zaehlung nonMatchingZaehlung1 = new Zaehlung();
+        nonMatchingZaehlung1.setZaehlart(Zaehlart.QU.name());
+        nonMatchingZaehlung1.setQuerungsverkehr(List.of(qv1));
+        assertThat(ProcessZaehldatenZeitreiheService.checkBewegungsbeziehung(zaehlung, new OptionsDTO(), nonMatchingZaehlung1), is(false));
 
-        // negative cases
-        options.setChosenQuerungsverkehre(List.of(new OptionsQuerungsverkehrDTO() {
-            {
-                setKnotenarm(1);
-                setRichtung(Himmelsrichtung.N);
-            }
-        }, new OptionsQuerungsverkehrDTO() {
-            {
-                setKnotenarm(2);
-                setRichtung(Himmelsrichtung.S);
-            }
-        }));
-        assertThat(ProcessZaehldatenZeitreiheService.checkBewegungsbeziehung(zaehlung, options), is(false));
+        Zaehlung nonMatchingZaehlung2 = new Zaehlung();
+        nonMatchingZaehlung2.setZaehlart(Zaehlart.QU.name());
+        Querungsverkehr qv3 = new Querungsverkehr();
+        qv3.setKnotenarm(2);
+        qv3.setRichtung(Himmelsrichtung.S);
+        nonMatchingZaehlung2.setQuerungsverkehr(List.of(qv3, qv2));
+        assertThat(ProcessZaehldatenZeitreiheService.checkBewegungsbeziehung(zaehlung, new OptionsDTO(), nonMatchingZaehlung2), is(false));
 
-        options.setChosenQuerungsverkehre(List.of(new OptionsQuerungsverkehrDTO() {
-            {
-                setKnotenarm(1);
-                setRichtung(Himmelsrichtung.W);
-            }
-        }));
-        assertThat(ProcessZaehldatenZeitreiheService.checkBewegungsbeziehung(zaehlung, options), is(false));
+        Zaehlung nonMatchingZaehlung3 = new Zaehlung();
+        nonMatchingZaehlung3.setZaehlart(Zaehlart.QU.name());
+        nonMatchingZaehlung3.setQuerungsverkehr(List.of(qv1, qv3));
+        assertThat(ProcessZaehldatenZeitreiheService.checkBewegungsbeziehung(zaehlung, new OptionsDTO(), nonMatchingZaehlung3), is(false));
+
+        Zaehlung nonMatchingZaehlung4 = new Zaehlung();
+        nonMatchingZaehlung4.setZaehlart(Zaehlart.QU.name());
+        Querungsverkehr qv4 = new Querungsverkehr();
+        qv4.setKnotenarm(1);
+        qv4.setRichtung(Himmelsrichtung.W);
+        nonMatchingZaehlung4.setQuerungsverkehr(List.of(qv2, qv4));
+        assertThat(ProcessZaehldatenZeitreiheService.checkBewegungsbeziehung(zaehlung, new OptionsDTO(), nonMatchingZaehlung4), is(false));
+
     }
 
     @Test
-    public void checkVerkehrsbeziehungenFJS() {
+    public void checkBewegungsbeziehungenFJS() {
         // setup
         Zaehlung zaehlung = new Zaehlung();
         zaehlung.setZaehlart(Zaehlart.FJS.name());
@@ -233,63 +213,48 @@ public class ProcessZaehldatenZeitreiheTest {
         zaehlung.setLaengsverkehr(List.of(l1, l2));
 
         // positive cases
-        OptionsDTO options = new OptionsDTO();
-        options.setChosenLaengsverkehre(List.of(new OptionsLaengsverkehrDTO() {
-            {
-                setKnotenarm(1);
-                setRichtung(Bewegungsrichtung.EIN);
-                setStrassenseite(Himmelsrichtung.N);
-            }
-        }));
-        assertThat(ProcessZaehldatenZeitreiheService.checkBewegungsbeziehung(zaehlung, options), is(true));
-
-        options.setChosenLaengsverkehre(List.of(new OptionsLaengsverkehrDTO() {
-            {
-                setKnotenarm(1);
-                setRichtung(Bewegungsrichtung.EIN);
-                setStrassenseite(Himmelsrichtung.N);
-            }
-        }, new OptionsLaengsverkehrDTO() {
-            {
-                setKnotenarm(1);
-                setRichtung(Bewegungsrichtung.AUS);
-                setStrassenseite(Himmelsrichtung.S);
-            }
-        }));
-        assertThat(ProcessZaehldatenZeitreiheService.checkBewegungsbeziehung(zaehlung, options), is(true));
+        Zaehlung matchingZaehlung = new Zaehlung();
+        matchingZaehlung.setZaehlart(Zaehlart.FJS.name());
+        matchingZaehlung.setLaengsverkehr(List.of(l1, l2));
+        assertThat(ProcessZaehldatenZeitreiheService.checkBewegungsbeziehung(zaehlung, new OptionsDTO(), matchingZaehlung), is(true));
 
         // negative cases
-        options.setChosenLaengsverkehre(List.of(new OptionsLaengsverkehrDTO() {
-            {
-                setKnotenarm(2);
-                setRichtung(Bewegungsrichtung.EIN);
-                setStrassenseite(Himmelsrichtung.N);
-            }
-        }));
-        assertThat(ProcessZaehldatenZeitreiheService.checkBewegungsbeziehung(zaehlung, options), is(false));
+        Zaehlung nonMatchingZaehlung1 = new Zaehlung();
+        nonMatchingZaehlung1.setZaehlart(Zaehlart.FJS.name());
+        nonMatchingZaehlung1.setLaengsverkehr(List.of(l1));
+        assertThat(ProcessZaehldatenZeitreiheService.checkBewegungsbeziehung(zaehlung, new OptionsDTO(), nonMatchingZaehlung1), is(false));
 
-        options.setChosenLaengsverkehre(List.of(new OptionsLaengsverkehrDTO() {
-            {
-                setKnotenarm(1);
-                setRichtung(Bewegungsrichtung.AUS);
-                setStrassenseite(Himmelsrichtung.N);
-            }
-        }));
-        assertThat(ProcessZaehldatenZeitreiheService.checkBewegungsbeziehung(zaehlung, options), is(false));
+        Zaehlung nonMatchingZaehlung2 = new Zaehlung();
+        nonMatchingZaehlung2.setZaehlart(Zaehlart.FJS.name());
+        Laengsverkehr l3 = new Laengsverkehr();
+        l3.setKnotenarm(2);
+        l3.setRichtung(Bewegungsrichtung.AUS);
+        l3.setStrassenseite(Himmelsrichtung.S);
+        nonMatchingZaehlung2.setLaengsverkehr(List.of(l1, l3));
+        assertThat(ProcessZaehldatenZeitreiheService.checkBewegungsbeziehung(zaehlung, new OptionsDTO(), nonMatchingZaehlung2), is(false));
 
-        options.setChosenLaengsverkehre(List.of(new OptionsLaengsverkehrDTO() {
-            {
-                setKnotenarm(1);
-                setRichtung(Bewegungsrichtung.EIN);
-                setStrassenseite(Himmelsrichtung.S);
-            }
-        }));
-        assertThat(ProcessZaehldatenZeitreiheService.checkBewegungsbeziehung(zaehlung, options), is(false));
+        Zaehlung nonMatchingZaehlung3 = new Zaehlung();
+        nonMatchingZaehlung3.setZaehlart(Zaehlart.FJS.name());
+        Laengsverkehr l4 = new Laengsverkehr();
+        l4.setKnotenarm(1);
+        l4.setRichtung(Bewegungsrichtung.EIN);
+        l4.setStrassenseite(Himmelsrichtung.S);
+        nonMatchingZaehlung3.setLaengsverkehr(List.of(l2, l4));
+        assertThat(ProcessZaehldatenZeitreiheService.checkBewegungsbeziehung(zaehlung, new OptionsDTO(), nonMatchingZaehlung3), is(false));
+
+        Zaehlung nonMatchingZaehlung4 = new Zaehlung();
+        nonMatchingZaehlung4.setZaehlart(Zaehlart.FJS.name());
+        Laengsverkehr l5 = new Laengsverkehr();
+        l5.setKnotenarm(1);
+        l5.setRichtung(Bewegungsrichtung.EIN);
+        l5.setStrassenseite(Himmelsrichtung.W);
+        nonMatchingZaehlung4.setLaengsverkehr(List.of(l1, l5));
+        assertThat(ProcessZaehldatenZeitreiheService.checkBewegungsbeziehung(zaehlung, new OptionsDTO(), nonMatchingZaehlung4), is(false));
 
     }
 
     @Test
-    public void checkVerkehrsbeziehungenQJS() {
+    public void checkBewegungsbeziehungenQJS() {
         // setup
         Zaehlung zaehlung = new Zaehlung();
         zaehlung.setZaehlart(Zaehlart.QJS.name());
@@ -303,58 +268,44 @@ public class ProcessZaehldatenZeitreiheTest {
         vb2.setStrassenseite(Himmelsrichtung.N);
         zaehlung.setVerkehrsbeziehungen(List.of(vb1, vb2));
 
-        // positive cases
-        OptionsDTO options = new OptionsDTO();
-        options.setChosenVerkehrsbeziehungen(List.of(new OptionsVerkehrsbeziehungDTO() {
-            {
-                setVon(1);
-                setNach(3);
-                setStrassenseite(Himmelsrichtung.N);
-            }
-        }));
-        assertThat(ProcessZaehldatenZeitreiheService.checkBewegungsbeziehung(zaehlung, options), is(true));
-
-        options.setChosenVerkehrsbeziehungen(List.of(new OptionsVerkehrsbeziehungDTO() {
-            {
-                setVon(1);
-                setNach(3);
-                setStrassenseite(Himmelsrichtung.N);
-            }
-        }, new OptionsVerkehrsbeziehungDTO() {
-            {
-                setVon(3);
-                setNach(1);
-                setStrassenseite(Himmelsrichtung.N);
-            }
-        }));
-        assertThat(ProcessZaehldatenZeitreiheService.checkBewegungsbeziehung(zaehlung, options), is(true));
+        // positive case
+        Zaehlung matchingZaehlung = new Zaehlung();
+        matchingZaehlung.setZaehlart(Zaehlart.QJS.name());
+        matchingZaehlung.setVerkehrsbeziehungen(List.of(vb1, vb2));
+        assertThat(ProcessZaehldatenZeitreiheService.checkBewegungsbeziehung(zaehlung, new OptionsDTO(), matchingZaehlung), is(true));
 
         // negative cases
-        options.setChosenVerkehrsbeziehungen(List.of(new OptionsVerkehrsbeziehungDTO() {
-            {
-                setVon(1);
-                setNach(3);
-                setStrassenseite(Himmelsrichtung.S);
-            }
-        }));
-        assertThat(ProcessZaehldatenZeitreiheService.checkBewegungsbeziehung(zaehlung, options), is(false));
+        Zaehlung nonMatchingZaehlung1 = new Zaehlung();
+        nonMatchingZaehlung1.setZaehlart(Zaehlart.QJS.name());
+        nonMatchingZaehlung1.setVerkehrsbeziehungen(List.of(vb1));
+        assertThat(ProcessZaehldatenZeitreiheService.checkBewegungsbeziehung(zaehlung, new OptionsDTO(), nonMatchingZaehlung1), is(false));
 
-        options.setChosenVerkehrsbeziehungen(List.of(new OptionsVerkehrsbeziehungDTO() {
-            {
-                setVon(3);
-                setNach(3);
-                setStrassenseite(Himmelsrichtung.N);
-            }
-        }));
-        assertThat(ProcessZaehldatenZeitreiheService.checkBewegungsbeziehung(zaehlung, options), is(false));
+        Zaehlung nonMatchingZaehlung2 = new Zaehlung();
+        nonMatchingZaehlung2.setZaehlart(Zaehlart.QJS.name());
+        Verkehrsbeziehung vb3 = new Verkehrsbeziehung();
+        vb3.setVon(1);
+        vb3.setNach(1);
+        vb3.setStrassenseite(Himmelsrichtung.N);
+        nonMatchingZaehlung2.setVerkehrsbeziehungen(List.of(vb1, vb3));
+        assertThat(ProcessZaehldatenZeitreiheService.checkBewegungsbeziehung(zaehlung, new OptionsDTO(), nonMatchingZaehlung2), is(false));
 
-        options.setChosenVerkehrsbeziehungen(List.of(new OptionsVerkehrsbeziehungDTO() {
-            {
-                setVon(1);
-                setNach(1);
-                setStrassenseite(Himmelsrichtung.N);
-            }
-        }));
-        assertThat(ProcessZaehldatenZeitreiheService.checkBewegungsbeziehung(zaehlung, options), is(false));
+        Zaehlung nonMatchingZaehlung3 = new Zaehlung();
+        nonMatchingZaehlung3.setZaehlart(Zaehlart.QJS.name());
+        Verkehrsbeziehung vb4 = new Verkehrsbeziehung();
+        vb4.setVon(3);
+        vb4.setNach(2);
+        vb4.setStrassenseite(Himmelsrichtung.N);
+        nonMatchingZaehlung3.setVerkehrsbeziehungen(List.of(vb2, vb4));
+        assertThat(ProcessZaehldatenZeitreiheService.checkBewegungsbeziehung(zaehlung, new OptionsDTO(), nonMatchingZaehlung3), is(false));
+
+        Zaehlung nonMatchingZaehlung4 = new Zaehlung();
+        nonMatchingZaehlung4.setZaehlart(Zaehlart.QJS.name());
+        Verkehrsbeziehung vb5 = new Verkehrsbeziehung();
+        vb5.setVon(3);
+        vb5.setNach(1);
+        vb5.setStrassenseite(Himmelsrichtung.S);
+        nonMatchingZaehlung4.setVerkehrsbeziehungen(List.of(vb1, vb5));
+        assertThat(ProcessZaehldatenZeitreiheService.checkBewegungsbeziehung(zaehlung, new OptionsDTO(), nonMatchingZaehlung4), is(false));
+
     }
 }

--- a/src/test/java/de/muenchen/dave/services/processzaehldaten/ProcessZaehldatenZeitreiheTest.java
+++ b/src/test/java/de/muenchen/dave/services/processzaehldaten/ProcessZaehldatenZeitreiheTest.java
@@ -4,10 +4,14 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 import de.muenchen.dave.domain.dtos.OptionsDTO;
+import de.muenchen.dave.domain.dtos.OptionsLaengsverkehrDTO;
+import de.muenchen.dave.domain.dtos.OptionsQuerungsverkehrDTO;
+import de.muenchen.dave.domain.dtos.OptionsVerkehrsbeziehungDTO;
 import de.muenchen.dave.domain.dtos.laden.LadeZaehldatenZeitreiheDTO;
 import de.muenchen.dave.domain.dtos.laden.LadeZaehldatumDTO;
-import de.muenchen.dave.domain.elasticsearch.Zaehlstelle;
-import de.muenchen.dave.domain.elasticsearch.Zaehlung;
+import de.muenchen.dave.domain.elasticsearch.*;
+import de.muenchen.dave.domain.enums.Bewegungsrichtung;
+import de.muenchen.dave.domain.enums.Himmelsrichtung;
 import de.muenchen.dave.domain.enums.Zaehlart;
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -145,4 +149,185 @@ public class ProcessZaehldatenZeitreiheTest {
         assertThat(ProcessZaehldatenZeitreiheService.calculateGesamt(kfz, fussgaenger, fahrradfahrer), is(new BigDecimal(1000)));
     }
 
+    @Test
+    public void checkVerkehrsbeziehungenQU() {
+        // setup
+        Zaehlung zaehlung = new Zaehlung();
+        zaehlung.setZaehlart(Zaehlart.QU.name());
+        Querungsverkehr qv1 = new Querungsverkehr();
+        qv1.setKnotenarm(1);
+        qv1.setRichtung(Himmelsrichtung.N);
+        Querungsverkehr qv2 = new Querungsverkehr();
+        qv2.setKnotenarm(1);
+        qv2.setRichtung(Himmelsrichtung.S);
+        zaehlung.setQuerungsverkehr(List.of(qv1, qv2));
+
+        // positive cases
+        OptionsDTO options = new OptionsDTO();
+        options.setChosenQuerungsverkehre(List.of(new OptionsQuerungsverkehrDTO() {
+            {
+                setKnotenarm(1);
+                setRichtung(Himmelsrichtung.N);
+            }
+        }));
+        assertThat(ProcessZaehldatenZeitreiheService.checkVerkehrsbeziehungen(zaehlung, options), is(true));
+
+        options.setChosenQuerungsverkehre(List.of(new OptionsQuerungsverkehrDTO() {
+            {
+                setKnotenarm(1);
+                setRichtung(Himmelsrichtung.N);
+            }
+        }, new OptionsQuerungsverkehrDTO() {
+            {
+                setKnotenarm(1);
+                setRichtung(Himmelsrichtung.S);
+            }
+        }));
+        assertThat(ProcessZaehldatenZeitreiheService.checkVerkehrsbeziehungen(zaehlung, options), is(true));
+
+        // negative cases
+        options.setChosenQuerungsverkehre(List.of(new OptionsQuerungsverkehrDTO() {
+            {
+                setKnotenarm(2);
+                setRichtung(Himmelsrichtung.N);
+            }
+        }));
+        assertThat(ProcessZaehldatenZeitreiheService.checkVerkehrsbeziehungen(zaehlung, options), is(false));
+
+        // negative cases
+        options.setChosenQuerungsverkehre(List.of(new OptionsQuerungsverkehrDTO() {
+            {
+                setKnotenarm(1);
+                setRichtung(Himmelsrichtung.N);
+            }
+        }, new OptionsQuerungsverkehrDTO() {
+            {
+                setKnotenarm(2);
+                setRichtung(Himmelsrichtung.S);
+            }
+        }));
+        assertThat(ProcessZaehldatenZeitreiheService.checkVerkehrsbeziehungen(zaehlung, options), is(false));
+    }
+
+    @Test
+    public void checkVerkehrsbeziehungenFJS() {
+        // setup
+        Zaehlung zaehlung = new Zaehlung();
+        zaehlung.setZaehlart(Zaehlart.FJS.name());
+        Laengsverkehr l1 = new Laengsverkehr();
+        l1.setKnotenarm(1);
+        l1.setRichtung(Bewegungsrichtung.EIN);
+        l1.setStrassenseite(Himmelsrichtung.N);
+        Laengsverkehr l2 = new Laengsverkehr();
+        l2.setKnotenarm(1);
+        l2.setRichtung(Bewegungsrichtung.AUS);
+        l2.setStrassenseite(Himmelsrichtung.N);
+        zaehlung.setLaengsverkehr(List.of(l1, l2));
+
+        // positive cases
+        OptionsDTO options = new OptionsDTO();
+        options.setChosenLaengsverkehre(List.of(new OptionsLaengsverkehrDTO() {
+            {
+                setKnotenarm(1);
+                setRichtung(Bewegungsrichtung.EIN);
+                setStrassenseite(Himmelsrichtung.N);
+            }
+        }));
+        assertThat(ProcessZaehldatenZeitreiheService.checkVerkehrsbeziehungen(zaehlung, options), is(true));
+
+        options.setChosenLaengsverkehre(List.of(new OptionsLaengsverkehrDTO() {
+            {
+                setKnotenarm(1);
+                setRichtung(Bewegungsrichtung.EIN);
+                setStrassenseite(Himmelsrichtung.N);
+            }
+        }, new OptionsLaengsverkehrDTO() {
+            {
+                setKnotenarm(1);
+                setRichtung(Bewegungsrichtung.AUS);
+                setStrassenseite(Himmelsrichtung.N);
+            }
+        }));
+        assertThat(ProcessZaehldatenZeitreiheService.checkVerkehrsbeziehungen(zaehlung, options), is(true));
+
+        // negative cases
+        options.setChosenLaengsverkehre(List.of(new OptionsLaengsverkehrDTO() {
+            {
+                setKnotenarm(2);
+                setRichtung(Bewegungsrichtung.EIN);
+                setStrassenseite(Himmelsrichtung.N);
+            }
+        }));
+        assertThat(ProcessZaehldatenZeitreiheService.checkVerkehrsbeziehungen(zaehlung, options), is(false));
+
+        options.setChosenLaengsverkehre(List.of(new OptionsLaengsverkehrDTO() {
+            {
+                setKnotenarm(1);
+                setRichtung(Bewegungsrichtung.AUS);
+                setStrassenseite(Himmelsrichtung.S);
+            }
+        }));
+        assertThat(ProcessZaehldatenZeitreiheService.checkVerkehrsbeziehungen(zaehlung, options), is(false));
+
+        options.setChosenLaengsverkehre(List.of(new OptionsLaengsverkehrDTO() {
+            {
+                setKnotenarm(1);
+                setRichtung(Bewegungsrichtung.EIN);
+                setStrassenseite(Himmelsrichtung.S);
+            }
+        }));
+        assertThat(ProcessZaehldatenZeitreiheService.checkVerkehrsbeziehungen(zaehlung, options), is(false));
+    }
+
+    @Test
+    public void checkVerkehrsbeziehungenQJS() {
+        // setup
+        Zaehlung zaehlung = new Zaehlung();
+        zaehlung.setZaehlart(Zaehlart.QJS.name());
+        Verkehrsbeziehung vb1 = new Verkehrsbeziehung();
+        vb1.setVon(1);
+        vb1.setNach(3);
+        vb1.setStrassenseite(Himmelsrichtung.N);
+        Verkehrsbeziehung vb2 = new Verkehrsbeziehung();
+        vb2.setVon(3);
+        vb2.setNach(1);
+        vb2.setStrassenseite(Himmelsrichtung.N);
+        zaehlung.setVerkehrsbeziehungen(List.of(vb1, vb2));
+
+        // positive cases
+        OptionsDTO options = new OptionsDTO();
+        options.setChosenVerkehrsbeziehungen(List.of(new OptionsVerkehrsbeziehungDTO() {
+            {
+                setVon(1);
+                setNach(3);
+                setStrassenseite(Himmelsrichtung.N);
+            }
+        }));
+        assertThat(ProcessZaehldatenZeitreiheService.checkVerkehrsbeziehungen(zaehlung, options), is(true));
+
+        options.setChosenVerkehrsbeziehungen(List.of(new OptionsVerkehrsbeziehungDTO() {
+            {
+                setVon(1);
+                setNach(3);
+                setStrassenseite(Himmelsrichtung.N);
+            }
+        }, new OptionsVerkehrsbeziehungDTO() {
+            {
+                setVon(3);
+                setNach(1);
+                setStrassenseite(Himmelsrichtung.N);
+            }
+        }));
+        assertThat(ProcessZaehldatenZeitreiheService.checkVerkehrsbeziehungen(zaehlung, options), is(true));
+
+        // negative cases
+        options.setChosenVerkehrsbeziehungen(List.of(new OptionsVerkehrsbeziehungDTO() {
+            {
+                setVon(1);
+                setNach(3);
+                setStrassenseite(Himmelsrichtung.S);
+            }
+        }));
+        assertThat(ProcessZaehldatenZeitreiheService.checkVerkehrsbeziehungen(zaehlung, options), is(false));
+    }
 }


### PR DESCRIPTION
# Description

Anpassung des Filtermenü Zählungsvergleich hinsichtlich Zeitreihe für die neuen Zählarten

# Issue References

[FV-262](https://jira.muenchen.de/browse/FV-262)
 
# Definition of Done

<!-- Check all completed DoD requirements here -->

- [x] Acceptance criteria are met
- [x] Testing is done (unit-tests, DEV-environment)
- [x] Build/Test workflow has successfully finished
- [x] Release notes are complemented
- [x] Documentation is complemented (operator manual, system specification, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for three traffic-counting modes to ensure option selections match available relationships.
  * Suppressed zero-filled placeholder time entries for those modes to avoid misleading time series labels.
  * Simplified internal time-selection handling to avoid using a precomputed selection where not needed.

* **Tests**
  * Added tests covering validation behavior for the three counting modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->