### PR TITLE
Adjustement style=width...

### DIFF
--- a/src/main/resources/pdf/templates/belastungsplan.mustache
+++ b/src/main/resources/pdf/templates/belastungsplan.mustache
@@ -19,7 +19,7 @@
 {{/belastungsplanKreisverkehr}}
 
 {{#chart}}
-  <img style="width: 95%" src="{{chart}}"/>
+  <img style="width: 90%" src="{{chart}}"/>
 {{/chart}}
 {{{zusatzinformationenMustachePart}}}
 </body>

--- a/src/test/java/de/muenchen/dave/services/pdfgenerator/GeneratePdfServiceTest.java
+++ b/src/test/java/de/muenchen/dave/services/pdfgenerator/GeneratePdfServiceTest.java
@@ -175,8 +175,7 @@ class GeneratePdfServiceTest {
 
         final String expected;
 
-        expected = String.format(
-                "<html>%n<head>%n  <style></style>%n</head>%n<body>%nNur ein Test-Template.%n<header>Der Header</header>%n%n<footer>Der Footer</footer>%n%n14.12.2020%n&lt;TestOU&gt;%n</body>%n</html>");
+        expected = "<html>\n<head>\n  <style></style>\n</head>\n<body>\nNur ein Test-Template.\n<header>Der Header</header>\n\n<footer>Der Footer</footer>\n\n14.12.2020\n&lt;TestOU&gt;\n</body>\n</html>";
 
         assertThat(html, is(expected));
     }


### PR DESCRIPTION
# Description

During PDF generation, the graphic is moved to the next page if street names are too long.

# Issue References

FV_379
 
# Definition of Done

<!-- Check all completed DoD requirements here -->

- [x] Acceptance criteria are met
- [x] Testing is done (unit-tests, DEV-environment)
- [x] Build/Test workflow has successfully finished
- [x] Release notes are complemented
- [x] Documentation is complemented (operator manual, system specification, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted PDF chart image sizing so the chart renders slightly smaller and fits the page layout better.
* **Tests**
  * Updated the PDF HTML test to use consistent newline handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->