### PR TITLE
FV-437 Zeitreihe CSV 2

### DIFF
--- a/src/main/java/de/muenchen/dave/services/processzaehldaten/ProcessZaehldatenZeitreiheService.java
+++ b/src/main/java/de/muenchen/dave/services/processzaehldaten/ProcessZaehldatenZeitreiheService.java
@@ -8,10 +8,7 @@ import de.muenchen.dave.domain.dtos.laden.LadeZaehldatumDTO;
 import de.muenchen.dave.domain.elasticsearch.Verkehrsbeziehung;
 import de.muenchen.dave.domain.elasticsearch.Zaehlstelle;
 import de.muenchen.dave.domain.elasticsearch.Zaehlung;
-import de.muenchen.dave.domain.enums.Status;
-import de.muenchen.dave.domain.enums.Zaehlart;
-import de.muenchen.dave.domain.enums.Zaehldauer;
-import de.muenchen.dave.domain.enums.Zeitblock;
+import de.muenchen.dave.domain.enums.*;
 import de.muenchen.dave.exceptions.DataNotFoundException;
 import de.muenchen.dave.services.ZaehlstelleIndexService;
 import de.muenchen.dave.services.ZeitauswahlService;
@@ -37,6 +34,11 @@ public class ProcessZaehldatenZeitreiheService {
     private static final String VERKEHRSBEZIEHUNG_NICHT_VORHANDEN = "\n(Verkehrsbez. nicht vorh.)";
     private static final String FUSSVERKEHR_NICHT_VORHANDEN = "\n(Fußverkehr nicht vorh.)";
     private static final String RADVERKEHR_NICHT_VORHANDEN = "\n(Radverkehr nicht vorh.)";
+    public static final String KFZ_NICHT_VORH = "\n(KFZ nicht vorh.)";
+    public static final String GV_NICHT_VORH = "\n(GV nicht vorh.)";
+    public static final String SV_NICHT_VORH = "\n(SV nicht vorh.)";
+    public static final String SV_P_NICHT_VORH = "\n(SV-P nicht vorh.)";
+    public static final String GV_P_NICHT_VORH = "\n(GV-P nicht vorh.)";
 
     private final ZaehldatenExtractorService zaehldatenExtractorService;
 
@@ -83,23 +85,31 @@ public class ProcessZaehldatenZeitreiheService {
 
     /**
      * Befüllt das übergebene ladeZaehldatenZeitreiheDTO Objekt mit den Zeitreihe-Daten
+     * Dabei wird geprüft, ob die Kategorie existiert/gezählt wurde. Wenn sie nicht existiert, wird der
+     * Wert null
+     * zurückgegeben statt 0 um von einem tatsächlich gezählten 0 Wert unterscheiden zu können.
      *
      * @param options Optionen aus dem Frontend
      * @param ladeZaehldatenZeitreiheDTO Objekt, das befüllt werden soll
      * @param ladeZaehldatumDTO Objekt mit den Werten
+     * @param kategorien Liste der gezählten Fahrzeugkategorien
      */
     static void fillLadeZaehldatenZeitreiheDTO(
             final OptionsDTO options,
             final LadeZaehldatenZeitreiheDTO ladeZaehldatenZeitreiheDTO,
-            final LadeZaehldatumDTO ladeZaehldatumDTO) {
+            final LadeZaehldatumDTO ladeZaehldatumDTO,
+            final List<Fahrzeug> kategorien) {
         if (options.getKraftfahrzeugverkehr()) {
-            ladeZaehldatenZeitreiheDTO.getKfz().add(ladeZaehldatumDTO.getKfz());
+            // Wenn Kategorie KFZ nicht vorhanden ist, null liefern statt 0
+            ladeZaehldatenZeitreiheDTO.getKfz().add(kategorien.contains(Fahrzeug.KFZ)
+                    ? ladeZaehldatumDTO.getKfz()
+                    : null);
         }
         if (options.getSchwerverkehr()) {
-            ladeZaehldatenZeitreiheDTO.getSv().add(ladeZaehldatumDTO.getSchwerverkehr());
+            ladeZaehldatenZeitreiheDTO.getSv().add(kategorien.contains(Fahrzeug.SV) ? ladeZaehldatumDTO.getSchwerverkehr() : null);
         }
         if (options.getGueterverkehr()) {
-            ladeZaehldatenZeitreiheDTO.getGv().add(ladeZaehldatumDTO.getGueterverkehr());
+            ladeZaehldatenZeitreiheDTO.getGv().add(kategorien.contains(Fahrzeug.GV) ? ladeZaehldatumDTO.getGueterverkehr() : null);
         }
         if (options.getFussverkehr()) {
             ladeZaehldatenZeitreiheDTO.getFuss().add(ladeZaehldatumDTO.getFussgaenger());
@@ -108,14 +118,19 @@ public class ProcessZaehldatenZeitreiheService {
             ladeZaehldatenZeitreiheDTO.getRad().add(ladeZaehldatumDTO.getFahrradfahrer());
         }
         if (options.getSchwerverkehrsanteilProzent()) {
-            ladeZaehldatenZeitreiheDTO.getSvAnteilInProzent().add(ladeZaehldatumDTO.getAnteilSchwerverkehrAnKfzProzent());
+            ladeZaehldatenZeitreiheDTO.getSvAnteilInProzent()
+                    .add(kategorien.contains(Fahrzeug.SV_P) ? ladeZaehldatumDTO.getAnteilSchwerverkehrAnKfzProzent() : null);
         }
         if (options.getGueterverkehrsanteilProzent()) {
-            ladeZaehldatenZeitreiheDTO.getGvAnteilInProzent().add(ladeZaehldatumDTO.getAnteilGueterverkehrAnKfzProzent());
+            ladeZaehldatenZeitreiheDTO.getGvAnteilInProzent()
+                    .add(kategorien.contains(Fahrzeug.GV_P) ? ladeZaehldatumDTO.getAnteilGueterverkehrAnKfzProzent() : null);
         }
         if (options.getZeitreiheGesamt()) {
+            // wenn kein KFZ oder RAD vorhanden, null statt 0
             ladeZaehldatenZeitreiheDTO.getGesamt()
-                    .add(calculateGesamt(ladeZaehldatumDTO.getKfz(), ladeZaehldatumDTO.getFussgaenger(), ladeZaehldatumDTO.getFahrradfahrer()));
+                    .add(kategorien.contains(Fahrzeug.KFZ) || kategorien.contains(Fahrzeug.RAD)
+                            ? calculateGesamt(ladeZaehldatumDTO.getKfz(), ladeZaehldatumDTO.getFussgaenger(), ladeZaehldatumDTO.getFahrradfahrer())
+                            : null);
         }
     }
 
@@ -283,27 +298,49 @@ public class ProcessZaehldatenZeitreiheService {
                         final LadeZaehldatumDTO ladeZaehldatum = LadeZaehldatenService.mapToZaehldatum(zeitintervalle.getFirst(), zaehlung.getPkwEinheit(),
                                 options);
 
-                        String suffix = "";
-                        if (options.getFussverkehr() && ladeZaehldatum.getFussgaenger() == null) {
-                            suffix += FUSSVERKEHR_NICHT_VORHANDEN;
-                        }
-                        if (options.getRadverkehr() && ladeZaehldatum.getFahrradfahrer() == null) {
-                            suffix += RADVERKEHR_NICHT_VORHANDEN;
-                        }
+                        String suffix = getSuffix(options, zaehlung);
+
                         ladeZaehldatenZeitreihe.getDatum().add(zaehlung.getDatum().format(FillPdfBeanService.DDMMYYYY) + suffix);
 
-                        fillLadeZaehldatenZeitreiheDTO(options, ladeZaehldatenZeitreihe, ladeZaehldatum);
+                        fillLadeZaehldatenZeitreiheDTO(options, ladeZaehldatenZeitreihe, ladeZaehldatum, zaehlung.getKategorien());
                     } else {
                         // Wenn Zeitintervalle nicht vorhanden, ein leeres Objekt zurückgeben wenn kein QU, FJS oder QJS
                         if (!List.of(Zaehlart.QU.toString(), Zaehlart.FJS.toString(), Zaehlart.QJS.toString()).contains(zaehlung.getZaehlart())) {
                             final var ladeZaehldatum = getEmptyLadeZaehldatumDTO();
 
                             ladeZaehldatenZeitreihe.getDatum().add(zaehlung.getDatum().format(FillPdfBeanService.DDMMYYYY) + VERKEHRSBEZIEHUNG_NICHT_VORHANDEN);
-                            fillLadeZaehldatenZeitreiheDTO(options, ladeZaehldatenZeitreihe, ladeZaehldatum);
+                            fillLadeZaehldatenZeitreiheDTO(options, ladeZaehldatenZeitreihe, ladeZaehldatum, zaehlung.getKategorien());
                         }
                     }
                 });
         return ladeZaehldatenZeitreihe;
+    }
+
+    private static String getSuffix(OptionsDTO options, Zaehlung zaehlung) {
+        String suffix = "";
+
+        if (options.getRadverkehr() && !zaehlung.getKategorien().contains(Fahrzeug.RAD)) {
+            suffix += RADVERKEHR_NICHT_VORHANDEN;
+        }
+        if (options.getFussverkehr() && !zaehlung.getKategorien().contains(Fahrzeug.FUSS)) {
+            suffix += FUSSVERKEHR_NICHT_VORHANDEN;
+        }
+        if (options.getKraftfahrzeugverkehr() && !zaehlung.getKategorien().contains(Fahrzeug.KFZ)) {
+            suffix += KFZ_NICHT_VORH;
+        }
+        if (options.getGueterverkehr() && !zaehlung.getKategorien().contains(Fahrzeug.GV)) {
+            suffix += GV_NICHT_VORH;
+        }
+        if (options.getSchwerverkehr() && !zaehlung.getKategorien().contains(Fahrzeug.SV)) {
+            suffix += SV_NICHT_VORH;
+        }
+        if (options.getSchwerverkehrsanteilProzent() && !zaehlung.getKategorien().contains(Fahrzeug.SV_P)) {
+            suffix += SV_P_NICHT_VORH;
+        }
+        if (options.getGueterverkehrsanteilProzent() && !zaehlung.getKategorien().contains(Fahrzeug.GV_P)) {
+            suffix += GV_P_NICHT_VORH;
+        }
+        return suffix;
     }
 
     // Erstellt ein leeres LadeZaehldatumDTO

--- a/src/main/java/de/muenchen/dave/services/processzaehldaten/ProcessZaehldatenZeitreiheService.java
+++ b/src/main/java/de/muenchen/dave/services/processzaehldaten/ProcessZaehldatenZeitreiheService.java
@@ -108,10 +108,10 @@ public class ProcessZaehldatenZeitreiheService {
             ladeZaehldatenZeitreiheDTO.getGv().add(kategorien.contains(Fahrzeug.GV) ? ladeZaehldatumDTO.getGueterverkehr() : null);
         }
         if (options.getFussverkehr()) {
-            ladeZaehldatenZeitreiheDTO.getFuss().add(ladeZaehldatumDTO.getFussgaenger());
+            ladeZaehldatenZeitreiheDTO.getFuss().add(kategorien.contains(Fahrzeug.FUSS) ? ladeZaehldatumDTO.getFussgaenger() : null);
         }
         if (options.getRadverkehr()) {
-            ladeZaehldatenZeitreiheDTO.getRad().add(ladeZaehldatumDTO.getFahrradfahrer());
+            ladeZaehldatenZeitreiheDTO.getRad().add(kategorien.contains(Fahrzeug.RAD) ? ladeZaehldatumDTO.getFahrradfahrer() : null);
         }
         if (options.getSchwerverkehrsanteilProzent()) {
             ladeZaehldatenZeitreiheDTO.getSvAnteilInProzent()

--- a/src/main/java/de/muenchen/dave/services/processzaehldaten/ProcessZaehldatenZeitreiheService.java
+++ b/src/main/java/de/muenchen/dave/services/processzaehldaten/ProcessZaehldatenZeitreiheService.java
@@ -15,6 +15,7 @@ import de.muenchen.dave.services.ZeitauswahlService;
 import de.muenchen.dave.services.ladezaehldaten.LadeZaehldatenService;
 import de.muenchen.dave.services.ladezaehldaten.ZaehldatenExtractorService;
 import de.muenchen.dave.services.pdfgenerator.FillPdfBeanService;
+import de.muenchen.dave.util.ChartLegendUtil;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.*;
@@ -31,14 +32,9 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class ProcessZaehldatenZeitreiheService {
 
-    private static final String VERKEHRSBEZIEHUNG_NICHT_VORHANDEN = "\n(Verkehrsbez. nicht vorh.)";
-    private static final String FUSSVERKEHR_NICHT_VORHANDEN = "\n(Fußverkehr nicht vorh.)";
-    private static final String RADVERKEHR_NICHT_VORHANDEN = "\n(Radverkehr nicht vorh.)";
-    public static final String KFZ_NICHT_VORH = "\n(KFZ nicht vorh.)";
-    public static final String GV_NICHT_VORH = "\n(GV nicht vorh.)";
-    public static final String SV_NICHT_VORH = "\n(SV nicht vorh.)";
-    public static final String SV_P_NICHT_VORH = "\n(SV-P nicht vorh.)";
-    public static final String GV_P_NICHT_VORH = "\n(GV-P nicht vorh.)";
+    private static final String VERKEHRSBEZIEHUNG = "Verkehrsbez.";
+    public static final String MEHRERE_VERKEHRSARTEN = "mehrere Verkehrsarten";
+    public static final String NICHT_VORH = "\n(%s nicht vorh.)";
 
     private final ZaehldatenExtractorService zaehldatenExtractorService;
 
@@ -298,7 +294,7 @@ public class ProcessZaehldatenZeitreiheService {
                         final LadeZaehldatumDTO ladeZaehldatum = LadeZaehldatenService.mapToZaehldatum(zeitintervalle.getFirst(), zaehlung.getPkwEinheit(),
                                 options);
 
-                        String suffix = getSuffix(options, zaehlung);
+                        final String suffix = getSuffix(options, zaehlung.getKategorien());
 
                         ladeZaehldatenZeitreihe.getDatum().add(zaehlung.getDatum().format(FillPdfBeanService.DDMMYYYY) + suffix);
 
@@ -308,7 +304,8 @@ public class ProcessZaehldatenZeitreiheService {
                         if (!List.of(Zaehlart.QU.toString(), Zaehlart.FJS.toString(), Zaehlart.QJS.toString()).contains(zaehlung.getZaehlart())) {
                             final var ladeZaehldatum = getEmptyLadeZaehldatumDTO();
 
-                            ladeZaehldatenZeitreihe.getDatum().add(zaehlung.getDatum().format(FillPdfBeanService.DDMMYYYY) + VERKEHRSBEZIEHUNG_NICHT_VORHANDEN);
+                            ladeZaehldatenZeitreihe.getDatum()
+                                    .add(zaehlung.getDatum().format(FillPdfBeanService.DDMMYYYY) + String.format(NICHT_VORH, VERKEHRSBEZIEHUNG));
                             fillLadeZaehldatenZeitreiheDTO(options, ladeZaehldatenZeitreihe, ladeZaehldatum, zaehlung.getKategorien());
                         }
                     }
@@ -316,31 +313,65 @@ public class ProcessZaehldatenZeitreiheService {
         return ladeZaehldatenZeitreihe;
     }
 
-    private static String getSuffix(OptionsDTO options, Zaehlung zaehlung) {
-        String suffix = "";
+    /**
+     * Ermittelt Suffix für nicht vorhandene Verkehrsarten.
+     *
+     * @param options Filteroptionen fürs Auslesen der gewählten Fahrzeugkategorien
+     * @param kategorien beauftragte Fahrzeugkategorien
+     * @return Suffix
+     */
+    private static String getSuffix(final OptionsDTO options, final List<Fahrzeug> kategorien) {
+        int missing = 0;
+        if (options.getRadverkehr() && !kategorien.contains(Fahrzeug.RAD)) {
+            missing++;
+        }
+        if (options.getFussverkehr() && !kategorien.contains(Fahrzeug.FUSS)) {
+            missing++;
+        }
+        if (options.getKraftfahrzeugverkehr() && !kategorien.contains(Fahrzeug.KFZ)) {
+            missing++;
+        }
+        if (options.getGueterverkehr() && !kategorien.contains(Fahrzeug.GV)) {
+            missing++;
+        }
+        if (options.getSchwerverkehr() && !kategorien.contains(Fahrzeug.SV)) {
+            missing++;
+        }
+        if (options.getSchwerverkehrsanteilProzent() && !kategorien.contains(Fahrzeug.SV_P)) {
+            missing++;
+        }
+        if (options.getGueterverkehrsanteilProzent() && !kategorien.contains(Fahrzeug.GV_P)) {
+            missing++;
+        }
 
-        if (options.getRadverkehr() && !zaehlung.getKategorien().contains(Fahrzeug.RAD)) {
-            suffix += RADVERKEHR_NICHT_VORHANDEN;
+        // Wenn 2 oder mehr fehlen zusammenfassen
+        if (missing >= 2) {
+            return String.format(NICHT_VORH, MEHRERE_VERKEHRSARTEN);
         }
-        if (options.getFussverkehr() && !zaehlung.getKategorien().contains(Fahrzeug.FUSS)) {
-            suffix += FUSSVERKEHR_NICHT_VORHANDEN;
+
+        // Sonst Einzelausgabe
+        if (options.getRadverkehr() && !kategorien.contains(Fahrzeug.RAD)) {
+            return String.format(NICHT_VORH, ChartLegendUtil.RAD);
         }
-        if (options.getKraftfahrzeugverkehr() && !zaehlung.getKategorien().contains(Fahrzeug.KFZ)) {
-            suffix += KFZ_NICHT_VORH;
+        if (options.getFussverkehr() && !kategorien.contains(Fahrzeug.FUSS)) {
+            return String.format(NICHT_VORH, ChartLegendUtil.FUSSGAENGER);
         }
-        if (options.getGueterverkehr() && !zaehlung.getKategorien().contains(Fahrzeug.GV)) {
-            suffix += GV_NICHT_VORH;
+        if (options.getKraftfahrzeugverkehr() && !kategorien.contains(Fahrzeug.KFZ)) {
+            return String.format(NICHT_VORH, ChartLegendUtil.KFZ);
         }
-        if (options.getSchwerverkehr() && !zaehlung.getKategorien().contains(Fahrzeug.SV)) {
-            suffix += SV_NICHT_VORH;
+        if (options.getGueterverkehr() && !kategorien.contains(Fahrzeug.GV)) {
+            return String.format(NICHT_VORH, ChartLegendUtil.GUETERVERKEHR);
         }
-        if (options.getSchwerverkehrsanteilProzent() && !zaehlung.getKategorien().contains(Fahrzeug.SV_P)) {
-            suffix += SV_P_NICHT_VORH;
+        if (options.getSchwerverkehr() && !kategorien.contains(Fahrzeug.SV)) {
+            return String.format(NICHT_VORH, ChartLegendUtil.SCHWERVERKEHR);
         }
-        if (options.getGueterverkehrsanteilProzent() && !zaehlung.getKategorien().contains(Fahrzeug.GV_P)) {
-            suffix += GV_P_NICHT_VORH;
+        if (options.getSchwerverkehrsanteilProzent() && !kategorien.contains(Fahrzeug.SV_P)) {
+            return String.format(NICHT_VORH, ChartLegendUtil.SCHWERVERKEHR_ANTEIL_PROZENT);
         }
-        return suffix;
+        if (options.getGueterverkehrsanteilProzent() && !kategorien.contains(Fahrzeug.GV_P)) {
+            return String.format(NICHT_VORH, ChartLegendUtil.GUETERVERKEHR_ANTEIL_PROZENT);
+        }
+        return "";
     }
 
     // Erstellt ein leeres LadeZaehldatumDTO

--- a/src/test/java/de/muenchen/dave/services/processzaehldaten/ProcessZaehldatenZeitreiheTest.java
+++ b/src/test/java/de/muenchen/dave/services/processzaehldaten/ProcessZaehldatenZeitreiheTest.java
@@ -138,6 +138,103 @@ public class ProcessZaehldatenZeitreiheTest {
     }
 
     @Test
+    public void fillLadeZaehldatenZeitreiheDTO_missingCategoriesProducesNulls() {
+        final OptionsDTO options = new OptionsDTO();
+        options.setKraftfahrzeugverkehr(true);
+        options.setSchwerverkehr(true);
+        options.setGueterverkehr(true);
+        options.setFussverkehr(true);
+        options.setRadverkehr(true);
+        options.setSchwerverkehrsanteilProzent(true);
+        options.setGueterverkehrsanteilProzent(true);
+        options.setZeitreiheGesamt(true);
+
+        final LadeZaehldatumDTO ladeZaehldatumDTO = new LadeZaehldatumDTO();
+        ladeZaehldatumDTO.setPkw(100);
+        ladeZaehldatumDTO.setLkw(50);
+        ladeZaehldatumDTO.setLastzuege(20);
+        ladeZaehldatumDTO.setBusse(5);
+        ladeZaehldatumDTO.setKraftraeder(25);
+        ladeZaehldatumDTO.setFahrradfahrer(40);
+        ladeZaehldatumDTO.setFussgaenger(45);
+        ladeZaehldatumDTO.setPkwEinheiten(100);
+
+        // Kategorien ohne RAD und ohne SV_P (Schwerverkehrsanteil in Prozent fehlt)
+        final List<Fahrzeug> kategorien = List.of(Fahrzeug.KFZ, Fahrzeug.FUSS, Fahrzeug.GV_P, Fahrzeug.GV,
+                Fahrzeug.PKW, Fahrzeug.LKW, Fahrzeug.LZ, Fahrzeug.BUS, Fahrzeug.KRAD);
+
+        final LadeZaehldatenZeitreiheDTO result = new LadeZaehldatenZeitreiheDTO();
+        ProcessZaehldatenZeitreiheService.fillLadeZaehldatenZeitreiheDTO(options, result,
+                ladeZaehldatumDTO, kategorien);
+
+        assertThat(result.getRad().getFirst(), is((Integer) null));
+        assertThat(result.getFuss().getFirst(), is(45));
+        assertThat(result.getKfz().getFirst(), is(new BigDecimal(200)));
+        assertThat(result.getSvAnteilInProzent().getFirst(), is((BigDecimal) null));
+        assertThat(result.getGvAnteilInProzent().getFirst(), is(BigDecimal.valueOf(35.0)));
+    }
+
+    @Test
+    public void fillLadeZaehldatenZeitreiheDTO_zeitreiheGesamtNullWhenNoKfzOrRad() {
+        final OptionsDTO options = new OptionsDTO();
+
+        options.setKraftfahrzeugverkehr(false);
+        options.setSchwerverkehr(false);
+        options.setGueterverkehr(false);
+        options.setFussverkehr(false);
+        options.setRadverkehr(true); // Anfrage für Rad vorhanden
+        options.setSchwerverkehrsanteilProzent(false);
+        options.setGueterverkehrsanteilProzent(false);
+        options.setZeitreiheGesamt(true);
+
+        final LadeZaehldatumDTO ladeZaehldatumDTO = new LadeZaehldatumDTO();
+        ladeZaehldatumDTO.setPkw(100);
+        ladeZaehldatumDTO.setFahrradfahrer(40);
+        ladeZaehldatumDTO.setFussgaenger(10);
+        ladeZaehldatumDTO.setPkwEinheiten(100);
+
+        // Kategorien ohne KFZ und ohne RAD => Gesamt muss null sein
+        final List<Fahrzeug> kategorien = List.of(Fahrzeug.FUSS, Fahrzeug.GV_P);
+
+        final LadeZaehldatenZeitreiheDTO result = new LadeZaehldatenZeitreiheDTO();
+        ProcessZaehldatenZeitreiheService.fillLadeZaehldatenZeitreiheDTO(options, result,
+                ladeZaehldatumDTO, kategorien);
+
+        // Da weder KFZ noch RAD in kategorien vorhanden sind, muss Gesamt null sein
+        assertThat(result.getGesamt().getFirst(), is((BigDecimal) null));
+    }
+
+    @Test
+    public void fillLadeZaehldatenZeitreiheDTO_percentPresentButAbsoluteMissing() {
+        final OptionsDTO options = new OptionsDTO();
+        options.setKraftfahrzeugverkehr(false);
+        options.setSchwerverkehr(false);
+        options.setGueterverkehr(true);
+        options.setFussverkehr(false);
+        options.setRadverkehr(false);
+        options.setSchwerverkehrsanteilProzent(false);
+        options.setGueterverkehrsanteilProzent(true);
+        options.setZeitreiheGesamt(false);
+
+        final LadeZaehldatumDTO ladeZaehldatumDTO = new LadeZaehldatumDTO();
+        ladeZaehldatumDTO.setPkw(100);
+        ladeZaehldatumDTO.setFahrradfahrer(40);
+        ladeZaehldatumDTO.setFussgaenger(10);
+        ladeZaehldatumDTO.setPkwEinheiten(100);
+
+        // GV (absolute) fehlt, GV_P (prozent) ist vorhanden
+        final List<Fahrzeug> kategorien = List.of(Fahrzeug.GV_P);
+
+        final LadeZaehldatenZeitreiheDTO result = new LadeZaehldatenZeitreiheDTO();
+        ProcessZaehldatenZeitreiheService.fillLadeZaehldatenZeitreiheDTO(options, result,
+                ladeZaehldatumDTO, kategorien);
+
+        // Absoluter Gueterverkehr soll null sein, Prozentwert aber vorhanden in form von 0.0
+        assertThat(result.getGv().getFirst(), is((BigDecimal) null));
+        assertThat(result.getGvAnteilInProzent().getFirst(), is(BigDecimal.valueOf(0.0)));
+    }
+
+    @Test
     public void calculateGesamt() {
         BigDecimal kfz = new BigDecimal(1000);
         Integer fussgaenger = 100;

--- a/src/test/java/de/muenchen/dave/services/processzaehldaten/ProcessZaehldatenZeitreiheTest.java
+++ b/src/test/java/de/muenchen/dave/services/processzaehldaten/ProcessZaehldatenZeitreiheTest.java
@@ -8,6 +8,7 @@ import de.muenchen.dave.domain.dtos.laden.LadeZaehldatenZeitreiheDTO;
 import de.muenchen.dave.domain.dtos.laden.LadeZaehldatumDTO;
 import de.muenchen.dave.domain.elasticsearch.*;
 import de.muenchen.dave.domain.enums.Bewegungsrichtung;
+import de.muenchen.dave.domain.enums.Fahrzeug;
 import de.muenchen.dave.domain.enums.Himmelsrichtung;
 import de.muenchen.dave.domain.enums.Zaehlart;
 import java.math.BigDecimal;
@@ -102,9 +103,12 @@ public class ProcessZaehldatenZeitreiheTest {
         ladeZaehldatumDTO.setFussgaenger(45);
         ladeZaehldatumDTO.setPkwEinheiten(100);
 
+        final List<Fahrzeug> kategorien = List.of(Fahrzeug.KFZ, Fahrzeug.FUSS, Fahrzeug.GV_P, Fahrzeug.SV_P, Fahrzeug.GV, Fahrzeug.RAD, Fahrzeug.SV,
+                Fahrzeug.PKW, Fahrzeug.LKW, Fahrzeug.LZ, Fahrzeug.BUS, Fahrzeug.KRAD);
+
         final LadeZaehldatenZeitreiheDTO ladeZaehldatenZeitreiheDTO1 = new LadeZaehldatenZeitreiheDTO();
         ProcessZaehldatenZeitreiheService.fillLadeZaehldatenZeitreiheDTO(options, ladeZaehldatenZeitreiheDTO1,
-                ladeZaehldatumDTO);
+                ladeZaehldatumDTO, kategorien);
         assertThat(ladeZaehldatenZeitreiheDTO1.getKfz().getFirst(), is(new BigDecimal(200)));
         assertThat(ladeZaehldatenZeitreiheDTO1.getSv().getFirst(), is(new BigDecimal(75)));
         assertThat(ladeZaehldatenZeitreiheDTO1.getGv().getFirst(), is(new BigDecimal(70)));
@@ -123,7 +127,7 @@ public class ProcessZaehldatenZeitreiheTest {
 
         final LadeZaehldatenZeitreiheDTO ladeZaehldatenZeitreiheDTO2 = new LadeZaehldatenZeitreiheDTO();
         ProcessZaehldatenZeitreiheService.fillLadeZaehldatenZeitreiheDTO(options, ladeZaehldatenZeitreiheDTO2,
-                ladeZaehldatumDTO);
+                ladeZaehldatumDTO, kategorien);
         assertThat(ladeZaehldatenZeitreiheDTO2.getKfz().size(), is(0));
         assertThat(ladeZaehldatenZeitreiheDTO2.getSv().size(), is(0));
         assertThat(ladeZaehldatenZeitreiheDTO2.getGv().size(), is(0));


### PR DESCRIPTION
# Description

Wenn es zu einer Verkehrsart keine Werte gibt, diese aber im Filtermenü ausgewählt ist, dann wird ein Teil der Hinweismeldung (siehe Anhang) der Auswertung in der CSV-Datei unter der entsprechenden Verkehrsart angezeigt

# Issue References

https://jira.muenchen.de/browse/FV-437
 
# Definition of Done

<!-- Check all completed DoD requirements here -->

- [ ] Acceptance criteria are met
- [ ] Testing is done (unit-tests, DEV-environment)
- [ ] Build/Test workflow has successfully finished
- [ ] Release notes are complemented
- [ ] Documentation is complemented (operator manual, system specification, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved time-series results when selected traffic categories are unavailable.
  * Missing category-specific values are now clearly represented as unavailable instead of misleading numeric values.
  * Added clearer messaging for one or multiple missing traffic categories.
  * Overall totals are only shown when relevant traffic data is available.

* **Tests**
  * Updated coverage for category-aware time-series processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->