### PR TITLE
FV-432 SEC Sanitizing von Texten für PDF-Reports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -474,6 +474,12 @@
             <version>${shedlock.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.tika</groupId>
+            <artifactId>tika-core</artifactId>
+            <version>3.3.1</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
         <openapi-ui.version>2.8.17</openapi-ui.version>
         <openapi.jackson-databind-nullable>0.2.6</openapi.jackson-databind-nullable>
         <ai.onnxruntime>1.22.0</ai.onnxruntime>
+        <tika.version>3.3.1</tika.version>
 
         <!-- Linting & Formatting -->
         <spotless-maven-plugin.version>2.44.5</spotless-maven-plugin.version>
@@ -477,7 +478,7 @@
         <dependency>
             <groupId>org.apache.tika</groupId>
             <artifactId>tika-core</artifactId>
-            <version>3.3.1</version>
+            <version>${tika.version}</version>
         </dependency>
 
     </dependencies>

--- a/src/main/java/de/muenchen/dave/services/pdfgenerator/GeneratePdfService.java
+++ b/src/main/java/de/muenchen/dave/services/pdfgenerator/GeneratePdfService.java
@@ -12,6 +12,7 @@ import de.muenchen.dave.domain.dtos.laden.messwerte.LadeProcessedMesswerteDTO;
 import de.muenchen.dave.domain.dtos.messstelle.MessstelleOptionsDTO;
 import de.muenchen.dave.domain.dtos.messstelle.auswertung.MessstelleAuswertungOptionsDTO;
 import de.muenchen.dave.domain.pdf.MustacheBean;
+import de.muenchen.dave.domain.pdf.assets.TextAsset;
 import de.muenchen.dave.domain.pdf.templates.DatentabellePdf;
 import de.muenchen.dave.domain.pdf.templates.DiagrammPdf;
 import de.muenchen.dave.domain.pdf.templates.GangliniePdf;
@@ -32,6 +33,8 @@ import java.io.StringWriter;
 import java.util.Objects;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
+import org.jsoup.Jsoup;
+import org.jsoup.safety.Safelist;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Service;
@@ -279,6 +282,22 @@ public class GeneratePdfService {
         final StringWriter writer = new StringWriter();
         mustache.execute(writer, bean);
         return writer.toString();
+    }
+
+    /**
+     * Filtert aus dem HTML-String des übergebenen {@link TextAsset} alles Unerwünschte heraus und aktualisiert
+     * den Text des Assets.
+     *
+     * @param asset TextAsset mit dem HTML-Text
+     */
+    public void sanitizeAllowedHtml(TextAsset asset) {
+        String inputHtml = asset.getText();
+
+        Safelist safelist = Safelist.basic();
+        safelist.removeEnforcedAttribute("a", "rel");
+
+        String cleanedHtml = Jsoup.clean(inputHtml, safelist);
+        asset.setText(cleanedHtml);
     }
 
     /**

--- a/src/main/java/de/muenchen/dave/services/pdfgenerator/GeneratePdfService.java
+++ b/src/main/java/de/muenchen/dave/services/pdfgenerator/GeneratePdfService.java
@@ -33,6 +33,7 @@ import java.util.Set;
 import javax.imageio.ImageIO;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
+import org.apache.tika.Tika;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.safety.Safelist;
@@ -338,7 +339,7 @@ public class GeneratePdfService {
         String header = inputUri.substring(0, commaIndex);
         String base64 = inputUri.substring(commaIndex + 1);
 
-        // Nur png, jpeg und jpg akzeptieren
+        // Nur png, jpeg und jpg akzeptieren (in URI-Header prüfen)
         String format = header.substring("data:image/".length(), header.indexOf(';')).toLowerCase();
         if (!Set.of("png", "jpeg", "jpg").contains(format)) {
             throw new IllegalArgumentException("Unsupported image type");
@@ -356,6 +357,12 @@ public class GeneratePdfService {
             }
 
             byte[] imageBytes = Base64.getDecoder().decode(base64);
+
+            // Nur png, jpeg und jpg akzeptieren (in Byte-String prüfen)
+            String detectedMime = new Tika().detect(imageBytes);
+            if (!Set.of("image/png", "image/jpeg", "image/jpg").contains(detectedMime)) {
+                throw new IllegalArgumentException("Unsupported image type: " + detectedMime);
+            }
 
             // Größe des dekodierten Images prüfen
             if (imageBytes.length > MAX_IMAGE_SIZE_BYTES) {

--- a/src/main/java/de/muenchen/dave/services/pdfgenerator/GeneratePdfService.java
+++ b/src/main/java/de/muenchen/dave/services/pdfgenerator/GeneratePdfService.java
@@ -25,13 +25,12 @@ import de.muenchen.dave.domain.pdf.templates.messstelle.GanglinieMessstellePdf;
 import de.muenchen.dave.domain.pdf.templates.messstelle.GesamtauswertungMessstellePdf;
 import de.muenchen.dave.exceptions.DataNotFoundException;
 import jakarta.annotation.PostConstruct;
-
 import java.awt.image.BufferedImage;
 import java.io.*;
 import java.util.Base64;
 import java.util.Objects;
 import java.util.Set;
-
+import javax.imageio.ImageIO;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
 import org.jsoup.Jsoup;
@@ -40,8 +39,6 @@ import org.jsoup.safety.Safelist;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Service;
-
-import javax.imageio.ImageIO;
 
 @Service
 @Slf4j

--- a/src/main/java/de/muenchen/dave/services/pdfgenerator/GeneratePdfService.java
+++ b/src/main/java/de/muenchen/dave/services/pdfgenerator/GeneratePdfService.java
@@ -285,8 +285,8 @@ public class GeneratePdfService {
     }
 
     /**
-     * Filtert aus dem HTML-String des übergebenen {@link TextAsset} alles Unerwünschte heraus und aktualisiert
-     * den Text des Assets.
+     * Filtert aus dem HTML-String des übergebenen {@link TextAsset} alles Unerwünschte heraus und
+     * aktualisiert den Text des Assets.
      *
      * @param asset TextAsset mit dem HTML-Text
      */

--- a/src/main/java/de/muenchen/dave/services/pdfgenerator/GeneratePdfService.java
+++ b/src/main/java/de/muenchen/dave/services/pdfgenerator/GeneratePdfService.java
@@ -12,6 +12,7 @@ import de.muenchen.dave.domain.dtos.laden.messwerte.LadeProcessedMesswerteDTO;
 import de.muenchen.dave.domain.dtos.messstelle.MessstelleOptionsDTO;
 import de.muenchen.dave.domain.dtos.messstelle.auswertung.MessstelleAuswertungOptionsDTO;
 import de.muenchen.dave.domain.pdf.MustacheBean;
+import de.muenchen.dave.domain.pdf.assets.ImageAsset;
 import de.muenchen.dave.domain.pdf.assets.TextAsset;
 import de.muenchen.dave.domain.pdf.templates.DatentabellePdf;
 import de.muenchen.dave.domain.pdf.templates.DiagrammPdf;
@@ -24,13 +25,13 @@ import de.muenchen.dave.domain.pdf.templates.messstelle.GanglinieMessstellePdf;
 import de.muenchen.dave.domain.pdf.templates.messstelle.GesamtauswertungMessstellePdf;
 import de.muenchen.dave.exceptions.DataNotFoundException;
 import jakarta.annotation.PostConstruct;
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.StringWriter;
+
+import java.awt.image.BufferedImage;
+import java.io.*;
+import java.util.Base64;
 import java.util.Objects;
+import java.util.Set;
+
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
 import org.jsoup.Jsoup;
@@ -39,6 +40,8 @@ import org.jsoup.safety.Safelist;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Service;
+
+import javax.imageio.ImageIO;
 
 @Service
 @Slf4j
@@ -88,6 +91,12 @@ public class GeneratePdfService {
 
     // Font
     private static final String FONT_FAMILY_ROBOTO = "Roboto";
+
+    // Image URI Validierung
+    public static final long MAX_IMAGE_SIZE_BYTES = 10 * 1024 * 1024; // 10 MB
+    public static final int MAX_WIDTH = 10000;
+    public static final int MAX_HEIGHT = 10000;
+    public static final long MAX_PIXELS = 50_000_000L; // 50 Megapixel
 
     @Value("classpath:pdf/fonts/roboto/Roboto-Thin.ttf")
     Resource robotoThin;
@@ -305,6 +314,78 @@ public class GeneratePdfService {
         doc.outputSettings().prettyPrint(false).syntax(Document.OutputSettings.Syntax.xml);
 
         asset.setText(doc.body().html());
+    }
+
+    /**
+     * Überprüft die im übergebenen {@link ImageAsset} enthaltene Image URI und ersetzt diese durch
+     * eine neu kodierte sichere Kopie.
+     *
+     * @param asset ImageAsset mit dem src String des Bildes
+     */
+    public void sanitizeImageUri(ImageAsset asset) {
+        String inputUri = asset.getImage();
+
+        if (inputUri == null || inputUri.isBlank()) {
+            throw new IllegalArgumentException("Image is empty");
+        }
+
+        if (!inputUri.startsWith("data:image/")) {
+            throw new IllegalArgumentException("Only image data URIs are allowed");
+        }
+
+        int commaIndex = inputUri.indexOf(',');
+        if (commaIndex < 0) {
+            throw new IllegalArgumentException("Invalid data URI");
+        }
+
+        String header = inputUri.substring(0, commaIndex);
+        String base64 = inputUri.substring(commaIndex + 1);
+
+        // Nur png, jpeg und jpg akzeptieren
+        String format = header.substring("data:image/".length(), header.indexOf(';')).toLowerCase();
+        if (!Set.of("png", "jpeg", "jpg").contains(format)) {
+            throw new IllegalArgumentException("Unsupported image type");
+        }
+
+        if (base64.isBlank()) {
+            throw new IllegalArgumentException("Invalid data URI");
+        }
+
+        try {
+            // Frühzeitige Abschätzung der Größe des dekodierten Images
+            long estimatedDecodedSize = (long) base64.length() * 3 / 4;
+            if (estimatedDecodedSize > MAX_IMAGE_SIZE_BYTES) {
+                throw new IllegalArgumentException("Image exceeds maximum size");
+            }
+
+            byte[] imageBytes = Base64.getDecoder().decode(base64);
+
+            // Größe des dekodierten Images prüfen
+            if (imageBytes.length > MAX_IMAGE_SIZE_BYTES) {
+                throw new IllegalArgumentException("Image exceeds maximum size");
+            }
+
+            BufferedImage image = ImageIO.read(new ByteArrayInputStream(imageBytes));
+
+            // Bilddimension und Auflösung prüfen
+            int width = image.getWidth();
+            int height = image.getHeight();
+            if (width > MAX_WIDTH || height > MAX_HEIGHT) {
+                throw new IllegalArgumentException("Image dimensions too large");
+            }
+            if ((long) width * height > MAX_PIXELS) {
+                throw new IllegalArgumentException("Image has too many pixels");
+            }
+
+            // Neu kodieren
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            ImageIO.write(image, "png", out);
+
+            String safeUri = "data:image/png;base64," + Base64.getEncoder().encodeToString(out.toByteArray());
+            asset.setImage(safeUri);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**

--- a/src/main/java/de/muenchen/dave/services/pdfgenerator/GeneratePdfService.java
+++ b/src/main/java/de/muenchen/dave/services/pdfgenerator/GeneratePdfService.java
@@ -95,6 +95,7 @@ public class GeneratePdfService {
     public static final int MAX_WIDTH = 10000;
     public static final int MAX_HEIGHT = 10000;
     public static final long MAX_PIXELS = 50_000_000L; // 50 Megapixel
+    public static final Set<String> ALLOWED_MIME_TYPES = Set.of("image/png", "image/jpeg", "image/jpg");
 
     @Value("classpath:pdf/fonts/roboto/Roboto-Thin.ttf")
     Resource robotoThin;
@@ -340,8 +341,8 @@ public class GeneratePdfService {
         String base64 = inputUri.substring(commaIndex + 1);
 
         // Nur png, jpeg und jpg akzeptieren (in URI-Header prüfen)
-        String format = header.substring("data:image/".length(), header.indexOf(';')).toLowerCase();
-        if (!Set.of("png", "jpeg", "jpg").contains(format)) {
+        String mime = header.substring("data:".length(), header.indexOf(';')).toLowerCase();
+        if (!ALLOWED_MIME_TYPES.contains(mime)) {
             throw new IllegalArgumentException("Unsupported image type");
         }
 
@@ -360,7 +361,7 @@ public class GeneratePdfService {
 
             // Nur png, jpeg und jpg akzeptieren (in Byte-String prüfen)
             String detectedMime = new Tika().detect(imageBytes);
-            if (!Set.of("image/png", "image/jpeg", "image/jpg").contains(detectedMime)) {
+            if (!ALLOWED_MIME_TYPES.contains(detectedMime)) {
                 throw new IllegalArgumentException("Unsupported image type: " + detectedMime);
             }
 

--- a/src/main/java/de/muenchen/dave/services/pdfgenerator/GeneratePdfService.java
+++ b/src/main/java/de/muenchen/dave/services/pdfgenerator/GeneratePdfService.java
@@ -34,6 +34,7 @@ import java.util.Objects;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
 import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
 import org.jsoup.safety.Safelist;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.Resource;
@@ -295,9 +296,15 @@ public class GeneratePdfService {
 
         Safelist safelist = Safelist.basic();
         safelist.removeEnforcedAttribute("a", "rel");
+        Document.OutputSettings settings = new Document.OutputSettings();
+        settings.prettyPrint(false);
 
-        String cleanedHtml = Jsoup.clean(inputHtml, safelist);
-        asset.setText(cleanedHtml);
+        String cleanedHtml = Jsoup.clean(inputHtml, "", safelist, settings);
+
+        Document doc = Jsoup.parseBodyFragment(cleanedHtml);
+        doc.outputSettings().prettyPrint(false).syntax(Document.OutputSettings.Syntax.xml);
+
+        asset.setText(doc.body().html());
     }
 
     /**

--- a/src/main/java/de/muenchen/dave/services/pdfgenerator/ReportService.java
+++ b/src/main/java/de/muenchen/dave/services/pdfgenerator/ReportService.java
@@ -133,6 +133,7 @@ public class ReportService {
                 this.generatePdfService.sanitizeAllowedHtml((TextAsset) asset);
                 sb.append(this.generatePdfService.getHtml(this.textAssetMustache, asset));
             } else if (asset.getType().equals(AssetType.IMAGE)) {
+                this.generatePdfService.sanitizeImageUri((ImageAsset) asset);
                 sb.append(this.generatePdfService.getHtml(this.imageAssetMustache, asset));
             } else if (asset.getType().equals(AssetType.PAGEBREAK)) {
                 sb.append(this.generatePdfService.getHtml(this.pagebreakAssetMustache, asset));

--- a/src/main/java/de/muenchen/dave/services/pdfgenerator/ReportService.java
+++ b/src/main/java/de/muenchen/dave/services/pdfgenerator/ReportService.java
@@ -8,10 +8,7 @@ import de.muenchen.dave.domain.elasticsearch.Zaehlung;
 import de.muenchen.dave.domain.enums.AssetType;
 import de.muenchen.dave.domain.enums.Fahrzeug;
 import de.muenchen.dave.domain.mapper.LadeZaehldatumMapper;
-import de.muenchen.dave.domain.pdf.assets.BaseAsset;
-import de.muenchen.dave.domain.pdf.assets.DatatableAsset;
-import de.muenchen.dave.domain.pdf.assets.MessstelleDatatableAsset;
-import de.muenchen.dave.domain.pdf.assets.ZaehlungskenngroessenAsset;
+import de.muenchen.dave.domain.pdf.assets.*;
 import de.muenchen.dave.domain.pdf.helper.DatentabellePdfZaehldaten;
 import de.muenchen.dave.domain.pdf.helper.ZaehlungskenngroessenData;
 import de.muenchen.dave.domain.pdf.templates.ReportPdf;
@@ -133,6 +130,7 @@ public class ReportService {
 
         assetList.forEach(asset -> {
             if (asset.getType().equals(AssetType.TEXT)) {
+                this.generatePdfService.sanitizeAllowedHtml((TextAsset) asset);
                 sb.append(this.generatePdfService.getHtml(this.textAssetMustache, asset));
             } else if (asset.getType().equals(AssetType.IMAGE)) {
                 sb.append(this.generatePdfService.getHtml(this.imageAssetMustache, asset));

--- a/src/main/resources/pdf/templates/parts/report/heading1-asset.mustache
+++ b/src/main/resources/pdf/templates/parts/report/heading1-asset.mustache
@@ -1,1 +1,1 @@
-<h1 class="report">{{{text}}}</h1>
+<h1 class="report">{{text}}</h1>

--- a/src/main/resources/pdf/templates/parts/report/heading2-asset.mustache
+++ b/src/main/resources/pdf/templates/parts/report/heading2-asset.mustache
@@ -1,1 +1,1 @@
-<h2 class="report">{{{text}}}</h2>
+<h2 class="report">{{text}}</h2>

--- a/src/main/resources/pdf/templates/parts/report/heading3-asset.mustache
+++ b/src/main/resources/pdf/templates/parts/report/heading3-asset.mustache
@@ -1,1 +1,1 @@
-<h3 class="report">{{{text}}}</h3>
+<h3 class="report">{{text}}</h3>

--- a/src/main/resources/pdf/templates/parts/report/heading4-asset.mustache
+++ b/src/main/resources/pdf/templates/parts/report/heading4-asset.mustache
@@ -1,1 +1,1 @@
-<h4 class="report">{{{text}}}</h4>
+<h4 class="report">{{text}}</h4>

--- a/src/main/resources/pdf/templates/parts/report/heading5-asset.mustache
+++ b/src/main/resources/pdf/templates/parts/report/heading5-asset.mustache
@@ -1,1 +1,1 @@
-<h5 class="report">{{{text}}}</h5>
+<h5 class="report">{{text}}</h5>

--- a/src/test/java/de/muenchen/dave/services/pdfgenerator/GeneratePdfServiceTest.java
+++ b/src/test/java/de/muenchen/dave/services/pdfgenerator/GeneratePdfServiceTest.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
@@ -256,9 +257,9 @@ class GeneratePdfServiceTest {
         IllegalArgumentException ex3 = assertThrows(IllegalArgumentException.class, () -> generatePdfService.sanitizeImageUri(asset3));
         assertThat(ex3.getMessage(), is("Invalid data URI"));
 
-        // Nur png, jpeg und jpg akzeptieren
+        // Falscher MIME-Type im Header
         ImageAsset asset4 = new ImageAsset();
-        asset4.setImage("data:image/svg;base64,");
+        asset4.setImage("data:image/svg+xml;base64,");
         IllegalArgumentException ex4 = assertThrows(IllegalArgumentException.class, () -> generatePdfService.sanitizeImageUri(asset4));
         assertThat(ex4.getMessage(), is("Unsupported image type"));
 
@@ -292,12 +293,19 @@ class GeneratePdfServiceTest {
         IllegalArgumentException ex9 = assertThrows(IllegalArgumentException.class, () -> generatePdfService.sanitizeImageUri(asset9));
         assertThat(ex9.getMessage(), is("Image has too many pixels"));
 
-        // Zufällig erzeugtes Test-Bild wird akzeptiert
+        // Falscher MIME-Type im Byte-String
         ImageAsset asset10 = new ImageAsset();
+        String imageUriWithWrongMimeType = createTestSvgImageURIWithPngInHeader();
+        asset10.setImage(imageUriWithWrongMimeType);
+        IllegalArgumentException ex10 = assertThrows(IllegalArgumentException.class, () -> generatePdfService.sanitizeImageUri(asset10));
+        assertThat(ex10.getMessage(), is("Unsupported image type: image/svg+xml"));
+
+        // Zufällig erzeugtes Test-Bild wird akzeptiert
+        ImageAsset asset11 = new ImageAsset();
         String testImageUri = createTestImageURI(2000, 2000);
-        asset10.setImage(testImageUri);
-        generatePdfService.sanitizeImageUri(asset10);
-        assertThat(asset10.getImage(), is(testImageUri));
+        asset11.setImage(testImageUri);
+        generatePdfService.sanitizeImageUri(asset11);
+        assertThat(asset11.getImage(), is(testImageUri));
 
     }
 
@@ -342,5 +350,22 @@ class GeneratePdfServiceTest {
             throw new RuntimeException(e);
         }
         return "data:image/png;base64," + Base64.getEncoder().encodeToString(out.toByteArray());
+    }
+
+    /**
+     * Erzeugt eine Image URI eines SVG-Bildes. Im Header der Image URI steht 'png' statt 'svg+xml'.
+     *
+     * @return Image URI
+     */
+    public String createTestSvgImageURIWithPngInHeader() {
+        String svg =
+                """
+                <svg xmlns="http://www.w3.org/2000/svg">
+                    <rect width="100" height="100"/>
+                </svg>
+                """;
+
+        return "data:image/png;base64," +
+                Base64.getEncoder().encodeToString(svg.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/src/test/java/de/muenchen/dave/services/pdfgenerator/GeneratePdfServiceTest.java
+++ b/src/test/java/de/muenchen/dave/services/pdfgenerator/GeneratePdfServiceTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.Matchers.is;
 import com.github.mustachejava.DefaultMustacheFactory;
 import com.github.mustachejava.Mustache;
 import com.github.mustachejava.MustacheFactory;
+import de.muenchen.dave.domain.pdf.assets.TextAsset;
 import de.muenchen.dave.domain.pdf.components.ZaehlstelleninformationenPdfComponent;
 import de.muenchen.dave.domain.pdf.components.ZusatzinformationenPdfComponent;
 import de.muenchen.dave.domain.pdf.helper.DatentabellePdfZaehldaten;
@@ -181,4 +182,43 @@ class GeneratePdfServiceTest {
         assertThat(html, is(expected));
     }
 
+    @Test
+    public void testSanitizeAllowedHtml() {
+        // Harmloser HTML-Input bleibt erhalten
+        String allowedHtml = "<p>Hello <strong>World</strong>. Visit <a href=\"https://example.com\">Link</a> or <a href=\"mailto:foo@example.com\">Email</a></p>";
+        TextAsset assetWithAllowedHtml = new TextAsset();
+        assetWithAllowedHtml.setText(allowedHtml);
+        generatePdfService.sanitizeAllowedHtml(assetWithAllowedHtml);
+        String expected = "<p>Hello <strong>World</strong>. Visit <a href=\"https://example.com\">Link</a> or <a href=\"mailto:foo@example.com\">Email</a></p>";
+        assertThat(assetWithAllowedHtml.getText(), is(expected));
+
+        // Schädlicher / nicht erlaubter HTML-Input wird entfernt
+        String notAllowedHtml1 = "<p>Click <a href=\"javascript:alert('XSS')\">here</a></p><script>alert('x')</script>";
+        TextAsset assetWithNotAllowedHtml1 = new TextAsset();
+        assetWithNotAllowedHtml1.setText(notAllowedHtml1);
+        generatePdfService.sanitizeAllowedHtml(assetWithNotAllowedHtml1);
+        String expected1 = "<p>Click <a>here</a></p>";  // href mit nicht erlaubtem uri scheme sowie script tags werden entfernt
+        assertThat(assetWithNotAllowedHtml1.getText(), is(expected1));
+
+        String notAllowedHtml2 = "<p onclick=\"doEvil()\" style=\"color:red\" class=\"foo\">Hi</p>";
+        TextAsset assetWithNotAllowedHtml2 = new TextAsset();
+        assetWithNotAllowedHtml2.setText(notAllowedHtml2);
+        generatePdfService.sanitizeAllowedHtml(assetWithNotAllowedHtml2);
+        String expected2 = "<p>Hi</p>";  // onclick wird entfernt
+        assertThat(assetWithNotAllowedHtml2.getText(), is(expected2));
+
+        String notAllowedHtml3 = "Before<img src=\"https://example.com/pic.png\" alt=\"pic\">After";
+        TextAsset assetWithNotAllowedHtml3 = new TextAsset();
+        assetWithNotAllowedHtml3.setText(notAllowedHtml3);
+        generatePdfService.sanitizeAllowedHtml(assetWithNotAllowedHtml3);
+        String expected3 = "BeforeAfter";  // img wird entfernt
+        assertThat(assetWithNotAllowedHtml3.getText(), is(expected3));
+
+        String notAllowedHtml4 = "<a href=\"/local/path\">Local</a>";
+        TextAsset assetWithNotAllowedHtml4 = new TextAsset();
+        assetWithNotAllowedHtml4.setText(notAllowedHtml4);
+        generatePdfService.sanitizeAllowedHtml(assetWithNotAllowedHtml4);
+        String expected4 = "<a>Local</a>";  // relative URL wird entfernt
+        assertThat(assetWithNotAllowedHtml4.getText(), is(expected4));
+    }
 }

--- a/src/test/java/de/muenchen/dave/services/pdfgenerator/GeneratePdfServiceTest.java
+++ b/src/test/java/de/muenchen/dave/services/pdfgenerator/GeneratePdfServiceTest.java
@@ -192,6 +192,13 @@ class GeneratePdfServiceTest {
         String expected = "<p>Hello <strong>World</strong>. Visit <a href=\"https://example.com\">Link</a> or <a href=\"mailto:foo@example.com\">Email</a></p>";
         assertThat(assetWithAllowedHtml.getText(), is(expected));
 
+        // Closing Tags (z.B. <br />) bleiben erhalten und werden nicht umgewandelt (z.B. <br /> -> <br> => Fehler bei der PDF-Generierung)
+        String allowedHtml2 = "Knotenarme:<br />1 1<br />2 2<br />";
+        TextAsset assetWithAllowedHtml2 = new TextAsset();
+        assetWithAllowedHtml2.setText(allowedHtml2);
+        generatePdfService.sanitizeAllowedHtml(assetWithAllowedHtml2);
+        assertThat(assetWithAllowedHtml2.getText(), is(allowedHtml2));
+
         // Schädlicher / nicht erlaubter HTML-Input wird entfernt
         String notAllowedHtml1 = "<p>Click <a href=\"javascript:alert('XSS')\">here</a></p><script>alert('x')</script>";
         TextAsset assetWithNotAllowedHtml1 = new TextAsset();

--- a/src/test/java/de/muenchen/dave/services/pdfgenerator/GeneratePdfServiceTest.java
+++ b/src/test/java/de/muenchen/dave/services/pdfgenerator/GeneratePdfServiceTest.java
@@ -358,8 +358,7 @@ class GeneratePdfServiceTest {
      * @return Image URI
      */
     public String createTestSvgImageURIWithPngInHeader() {
-        String svg =
-                """
+        String svg = """
                 <svg xmlns="http://www.w3.org/2000/svg">
                     <rect width="100" height="100"/>
                 </svg>

--- a/src/test/java/de/muenchen/dave/services/pdfgenerator/GeneratePdfServiceTest.java
+++ b/src/test/java/de/muenchen/dave/services/pdfgenerator/GeneratePdfServiceTest.java
@@ -197,28 +197,28 @@ class GeneratePdfServiceTest {
         TextAsset assetWithNotAllowedHtml1 = new TextAsset();
         assetWithNotAllowedHtml1.setText(notAllowedHtml1);
         generatePdfService.sanitizeAllowedHtml(assetWithNotAllowedHtml1);
-        String expected1 = "<p>Click <a>here</a></p>";  // href mit nicht erlaubtem uri scheme sowie script tags werden entfernt
+        String expected1 = "<p>Click <a>here</a></p>"; // href mit nicht erlaubtem uri scheme sowie script tags werden entfernt
         assertThat(assetWithNotAllowedHtml1.getText(), is(expected1));
 
         String notAllowedHtml2 = "<p onclick=\"doEvil()\" style=\"color:red\" class=\"foo\">Hi</p>";
         TextAsset assetWithNotAllowedHtml2 = new TextAsset();
         assetWithNotAllowedHtml2.setText(notAllowedHtml2);
         generatePdfService.sanitizeAllowedHtml(assetWithNotAllowedHtml2);
-        String expected2 = "<p>Hi</p>";  // onclick wird entfernt
+        String expected2 = "<p>Hi</p>"; // onclick wird entfernt
         assertThat(assetWithNotAllowedHtml2.getText(), is(expected2));
 
         String notAllowedHtml3 = "Before<img src=\"https://example.com/pic.png\" alt=\"pic\">After";
         TextAsset assetWithNotAllowedHtml3 = new TextAsset();
         assetWithNotAllowedHtml3.setText(notAllowedHtml3);
         generatePdfService.sanitizeAllowedHtml(assetWithNotAllowedHtml3);
-        String expected3 = "BeforeAfter";  // img wird entfernt
+        String expected3 = "BeforeAfter"; // img wird entfernt
         assertThat(assetWithNotAllowedHtml3.getText(), is(expected3));
 
         String notAllowedHtml4 = "<a href=\"/local/path\">Local</a>";
         TextAsset assetWithNotAllowedHtml4 = new TextAsset();
         assetWithNotAllowedHtml4.setText(notAllowedHtml4);
         generatePdfService.sanitizeAllowedHtml(assetWithNotAllowedHtml4);
-        String expected4 = "<a>Local</a>";  // relative URL wird entfernt
+        String expected4 = "<a>Local</a>"; // relative URL wird entfernt
         assertThat(assetWithNotAllowedHtml4.getText(), is(expected4));
     }
 }

--- a/src/test/java/de/muenchen/dave/services/pdfgenerator/GeneratePdfServiceTest.java
+++ b/src/test/java/de/muenchen/dave/services/pdfgenerator/GeneratePdfServiceTest.java
@@ -19,7 +19,6 @@ import de.muenchen.dave.domain.pdf.templates.DatentabellePdf;
 import de.muenchen.dave.domain.pdf.templates.DiagrammPdf;
 import de.muenchen.dave.domain.pdf.templates.GangliniePdf;
 import de.muenchen.dave.domain.pdf.templates.PdfBean;
-
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -30,12 +29,10 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
 import java.util.Random;
-
+import javax.imageio.ImageIO;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import javax.imageio.ImageIO;
 
 @Slf4j
 class GeneratePdfServiceTest {

--- a/src/test/java/de/muenchen/dave/services/pdfgenerator/GeneratePdfServiceTest.java
+++ b/src/test/java/de/muenchen/dave/services/pdfgenerator/GeneratePdfServiceTest.java
@@ -2,10 +2,12 @@ package de.muenchen.dave.services.pdfgenerator;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.github.mustachejava.DefaultMustacheFactory;
 import com.github.mustachejava.Mustache;
 import com.github.mustachejava.MustacheFactory;
+import de.muenchen.dave.domain.pdf.assets.ImageAsset;
 import de.muenchen.dave.domain.pdf.assets.TextAsset;
 import de.muenchen.dave.domain.pdf.components.ZaehlstelleninformationenPdfComponent;
 import de.muenchen.dave.domain.pdf.components.ZusatzinformationenPdfComponent;
@@ -17,14 +19,23 @@ import de.muenchen.dave.domain.pdf.templates.DatentabellePdf;
 import de.muenchen.dave.domain.pdf.templates.DiagrammPdf;
 import de.muenchen.dave.domain.pdf.templates.GangliniePdf;
 import de.muenchen.dave.domain.pdf.templates.PdfBean;
+
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
+import java.util.Random;
+
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import javax.imageio.ImageIO;
 
 @Slf4j
 class GeneratePdfServiceTest {
@@ -227,5 +238,113 @@ class GeneratePdfServiceTest {
         generatePdfService.sanitizeAllowedHtml(assetWithNotAllowedHtml4);
         String expected4 = "<a>Local</a>"; // relative URL wird entfernt
         assertThat(assetWithNotAllowedHtml4.getText(), is(expected4));
+    }
+
+    @Test
+    public void testSanitizeImageUri() {
+        // Leere Image URI
+        ImageAsset asset1 = new ImageAsset();
+        asset1.setImage("");
+        IllegalArgumentException ex1 = assertThrows(IllegalArgumentException.class, () -> generatePdfService.sanitizeImageUri(asset1));
+        assertThat(ex1.getMessage(), is("Image is empty"));
+
+        // Keine Image URI
+        ImageAsset asset2 = new ImageAsset();
+        asset2.setImage("data:text/plain;");
+        IllegalArgumentException ex2 = assertThrows(IllegalArgumentException.class, () -> generatePdfService.sanitizeImageUri(asset2));
+        assertThat(ex2.getMessage(), is("Only image data URIs are allowed"));
+
+        // Ungültige Image URI
+        ImageAsset asset3 = new ImageAsset();
+        asset3.setImage("data:image/png;base642141");
+        IllegalArgumentException ex3 = assertThrows(IllegalArgumentException.class, () -> generatePdfService.sanitizeImageUri(asset3));
+        assertThat(ex3.getMessage(), is("Invalid data URI"));
+
+        // Nur png, jpeg und jpg akzeptieren
+        ImageAsset asset4 = new ImageAsset();
+        asset4.setImage("data:image/svg;base64,");
+        IllegalArgumentException ex4 = assertThrows(IllegalArgumentException.class, () -> generatePdfService.sanitizeImageUri(asset4));
+        assertThat(ex4.getMessage(), is("Unsupported image type"));
+
+        // Leerer base64 Teil der URI
+        ImageAsset asset5 = new ImageAsset();
+        asset5.setImage("data:image/png;base64,");
+        IllegalArgumentException ex5 = assertThrows(IllegalArgumentException.class, () -> generatePdfService.sanitizeImageUri(asset5));
+        assertThat(ex5.getMessage(), is("Invalid data URI"));
+
+        // Image ist zu groß
+        ImageAsset asset6 = new ImageAsset();
+        asset6.setImage(createTooLargeTestImage());
+        IllegalArgumentException ex6 = assertThrows(IllegalArgumentException.class, () -> generatePdfService.sanitizeImageUri(asset6));
+        assertThat(ex6.getMessage(), is("Image exceeds maximum size"));
+
+        // Dimension width des Images ist zu groß
+        ImageAsset asset7 = new ImageAsset();
+        asset7.setImage(createTestImageURI(12000, 1000));
+        IllegalArgumentException ex7 = assertThrows(IllegalArgumentException.class, () -> generatePdfService.sanitizeImageUri(asset7));
+        assertThat(ex7.getMessage(), is("Image dimensions too large"));
+
+        // Dimension height des Images ist zu groß
+        ImageAsset asset8 = new ImageAsset();
+        asset8.setImage(createTestImageURI(1000, 12000));
+        IllegalArgumentException ex8 = assertThrows(IllegalArgumentException.class, () -> generatePdfService.sanitizeImageUri(asset8));
+        assertThat(ex8.getMessage(), is("Image dimensions too large"));
+
+        // Image hat zu große Auflösung
+        ImageAsset asset9 = new ImageAsset();
+        asset9.setImage(createTestImageURI(8000, 7000));
+        IllegalArgumentException ex9 = assertThrows(IllegalArgumentException.class, () -> generatePdfService.sanitizeImageUri(asset9));
+        assertThat(ex9.getMessage(), is("Image has too many pixels"));
+
+        // Zufällig erzeugtes Test-Bild wird akzeptiert
+        ImageAsset asset10 = new ImageAsset();
+        String testImageUri = createTestImageURI(2000, 2000);
+        asset10.setImage(testImageUri);
+        generatePdfService.sanitizeImageUri(asset10);
+        assertThat(asset10.getImage(), is(testImageUri));
+
+    }
+
+    /**
+     * Erzeugt eine Image URI zum Testen mit den übergebenen Werten für Höhe und Breite des Images.
+     *
+     * @param width Breite des Images
+     * @param height Höhe des Images
+     * @return Image URI
+     */
+    public String createTestImageURI(int width, int height) {
+        BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try {
+            ImageIO.write(image, "png", out);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return "data:image/png;base64," + Base64.getEncoder().encodeToString(out.toByteArray());
+    }
+
+    /**
+     * Erzeugt eine Image URI eines sehr großen Images zum Testen.
+     *
+     * @return Image URI
+     */
+    public String createTooLargeTestImage() {
+        BufferedImage image = new BufferedImage(5000, 5000, BufferedImage.TYPE_INT_RGB);
+
+        Random random = new Random();
+        for (int y = 0; y < image.getHeight(); y++) {
+            for (int x = 0; x < image.getWidth(); x++) {
+                int rgb = random.nextInt(0xFFFFFF);
+                image.setRGB(x, y, rgb);
+            }
+        }
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try {
+            ImageIO.write(image, "png", out);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return "data:image/png;base64," + Base64.getEncoder().encodeToString(out.toByteArray());
     }
 }


### PR DESCRIPTION
# Description

- Insert user inputs in mustache templates with {{ }} instead of {{{ }}}
- Add html sanitizing for texts
- Add sanitizing of image urls of user uploaded files

# Issue References

FV-432
 
# Definition of Done

<!-- Check all completed DoD requirements here -->

- [x] Acceptance criteria are met
- [x] Testing is done (unit-tests, DEV-environment)
- [x] Build/Test workflow has successfully finished
- [x] Release notes are complemented
- [x] Documentation is complemented (operator manual, system specification, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Added robust sanitization for report text HTML, removing unsafe tags/attributes and filtering unsafe links, before PDF rendering.
  * Validated embedded image data URIs (png/jpeg only), re-encoding to PNG and enforcing maximum size, width/height, and pixel-count limits.
  * Escaped heading text across report heading templates (h1–h5) to prevent unintended HTML rendering.
* **Bug Fixes**
  * Invalid HTML and malformed/oversized image data are now rejected or safely cleaned before PDF generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->