### PR TITLE
FV-480 Anpassung der Spitzenstundenbenneung

### DIFF
--- a/src/main/java/de/muenchen/dave/security/SecurityContextInformationExtractor.java
+++ b/src/main/java/de/muenchen/dave/security/SecurityContextInformationExtractor.java
@@ -33,10 +33,14 @@ public final class SecurityContextInformationExtractor {
     public static boolean isFachadmin() {
         log.debug("get isFachadmin");
         final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        return CollectionUtils
-                .emptyIfNull(authentication.getAuthorities())
-                .stream()
-                .anyMatch(grantedAuthority -> grantedAuthority.getAuthority().equals("ROLE_" + AuthoritiesEnum.FACHADMIN.name()));
+        return true;
+        /*
+         * return CollectionUtils
+         * .emptyIfNull(authentication.getAuthorities())
+         * .stream()
+         * .anyMatch(grantedAuthority -> grantedAuthority.getAuthority().equals("ROLE_" +
+         * AuthoritiesEnum.FACHADMIN.name()));
+         */
     }
 
     public static String getUserName() {

--- a/src/main/java/de/muenchen/dave/security/SecurityContextInformationExtractor.java
+++ b/src/main/java/de/muenchen/dave/security/SecurityContextInformationExtractor.java
@@ -33,14 +33,10 @@ public final class SecurityContextInformationExtractor {
     public static boolean isFachadmin() {
         log.debug("get isFachadmin");
         final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        return true;
-        /*
-         * return CollectionUtils
-         * .emptyIfNull(authentication.getAuthorities())
-         * .stream()
-         * .anyMatch(grantedAuthority -> grantedAuthority.getAuthority().equals("ROLE_" +
-         * AuthoritiesEnum.FACHADMIN.name()));
-         */
+        return CollectionUtils
+                .emptyIfNull(authentication.getAuthorities())
+                .stream()
+                .anyMatch(grantedAuthority -> grantedAuthority.getAuthority().equals("ROLE_" + AuthoritiesEnum.FACHADMIN.name()));
     }
 
     public static String getUserName() {

--- a/src/main/java/de/muenchen/dave/util/dataimport/ZeitintervallGleitendeSpitzenstundeUtil.java
+++ b/src/main/java/de/muenchen/dave/util/dataimport/ZeitintervallGleitendeSpitzenstundeUtil.java
@@ -28,6 +28,8 @@ import org.apache.commons.lang3.ObjectUtils;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class ZeitintervallGleitendeSpitzenstundeUtil {
 
+    private static final Set<Zeitblock> ZEITBLOECKE_FOR_SPSTD_DAY_SORTING_INDEX = Set.of(Zeitblock.ZB_00_24, Zeitblock.ZB_06_22, Zeitblock.ZB_06_19);
+
     /**
      * Mapping: für eine gegebene Zeitblock-Auswahl die Ziel-Zeitblöcke, die berechnet werden sollen
      */
@@ -270,7 +272,7 @@ public final class ZeitintervallGleitendeSpitzenstundeUtil {
      */
     public static int getSortingIndexKfz(final Zeitintervall zeitintervall, final Zeitblock zeitblock) {
         int sortingIndex;
-        if (zeitblock.equals(Zeitblock.ZB_00_24)) {
+        if (ZEITBLOECKE_FOR_SPSTD_DAY_SORTING_INDEX.contains(zeitblock)) {
             sortingIndex = ZeitintervallSortingIndexUtil.getSortingIndexSpitzenStundeCompleteDayKfz();
         } else {
             sortingIndex = ZeitintervallSortingIndexUtil.getFirstStepSortingIndex(zeitintervall);
@@ -288,11 +290,7 @@ public final class ZeitintervallGleitendeSpitzenstundeUtil {
      */
     public static int getSortingIndexRad(final Zeitintervall zeitintervall, final Zeitblock zeitblock) {
         int sortingIndex;
-        final var zeitbloeckeForDayIndex = Set.of(
-                Zeitblock.ZB_00_24,
-                Zeitblock.ZB_06_22,
-                Zeitblock.ZB_06_19);
-        if (zeitbloeckeForDayIndex.contains(zeitblock)) {
+        if (ZEITBLOECKE_FOR_SPSTD_DAY_SORTING_INDEX.contains(zeitblock)) {
             sortingIndex = ZeitintervallSortingIndexUtil.getSortingIndexSpitzenStundeCompleteDayRad();
         } else {
             sortingIndex = ZeitintervallSortingIndexUtil.getFirstStepSortingIndex(zeitintervall);
@@ -310,7 +308,7 @@ public final class ZeitintervallGleitendeSpitzenstundeUtil {
      */
     public static int getSortingIndexFuss(final Zeitintervall zeitintervall, final Zeitblock zeitblock) {
         int sortingIndex;
-        if (zeitblock.equals(Zeitblock.ZB_00_24)) {
+        if (ZEITBLOECKE_FOR_SPSTD_DAY_SORTING_INDEX.contains(zeitblock)) {
             sortingIndex = ZeitintervallSortingIndexUtil.getSortingIndexSpitzenStundeCompleteDayFuss();
         } else {
             sortingIndex = ZeitintervallSortingIndexUtil.getFirstStepSortingIndex(zeitintervall);

--- a/src/main/java/de/muenchen/dave/util/dataimport/ZeitintervallGleitendeSpitzenstundeUtil.java
+++ b/src/main/java/de/muenchen/dave/util/dataimport/ZeitintervallGleitendeSpitzenstundeUtil.java
@@ -288,7 +288,11 @@ public final class ZeitintervallGleitendeSpitzenstundeUtil {
      */
     public static int getSortingIndexRad(final Zeitintervall zeitintervall, final Zeitblock zeitblock) {
         int sortingIndex;
-        if (zeitblock.equals(Zeitblock.ZB_00_24)) {
+        final var zeitbloeckeForDayIndex = Set.of(
+                Zeitblock.ZB_00_24,
+                Zeitblock.ZB_06_22,
+                Zeitblock.ZB_06_19);
+        if (zeitbloeckeForDayIndex.contains(zeitblock)) {
             sortingIndex = ZeitintervallSortingIndexUtil.getSortingIndexSpitzenStundeCompleteDayRad();
         } else {
             sortingIndex = ZeitintervallSortingIndexUtil.getFirstStepSortingIndex(zeitintervall);


### PR DESCRIPTION
# Description

Bei Auswahl eines tagesumfassenden Zeitblocks wird der Text `SpStdTag` anstelle `SpStdBlock` gesetzt.

# Issue References

FV-480
 
# Definition of Done

<!-- Check all completed DoD requirements here -->

- [x] Acceptance criteria are met
- [x] Testing is done (unit-tests, DEV-environment)
- [x] Build/Test workflow has successfully finished
- [x] Release notes are complemented
- [x] Documentation is complemented (operator manual, system specification, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sorting of peak-hour results for additional full-day time intervals.
  * Ensured vehicle, bicycle, and pedestrian results use the appropriate sorting logic across supported time blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->