### PR TITLE
FV-427 Fehler bei 2x4h Zählung mit Filterauswahl nur SVP und GVP

### DIFF
--- a/src/main/java/de/muenchen/dave/services/processzaehldaten/ProcessZaehldatenHeatmapService.java
+++ b/src/main/java/de/muenchen/dave/services/processzaehldaten/ProcessZaehldatenHeatmapService.java
@@ -115,7 +115,7 @@ public class ProcessZaehldatenHeatmapService {
             // Split SeriesEntries (Y Axis) data
             splittedSize = ladeZaehldatenHeatmap.getSeriesEntriesFirstChart().size() / SPLIT_DIVISOR;
 
-            // Wenn keine Y Daten zum Splitten vorhanden sind (bei GV und SV), nicht splitten
+            // Wenn keine Y Daten zum Splitten vorhanden sind (bei GV% und SV%), nicht splitten
             if (splittedSize == 0) {
                 return;
             }

--- a/src/main/java/de/muenchen/dave/services/processzaehldaten/ProcessZaehldatenHeatmapService.java
+++ b/src/main/java/de/muenchen/dave/services/processzaehldaten/ProcessZaehldatenHeatmapService.java
@@ -115,6 +115,11 @@ public class ProcessZaehldatenHeatmapService {
             // Split SeriesEntries (Y Axis) data
             splittedSize = ladeZaehldatenHeatmap.getSeriesEntriesFirstChart().size() / SPLIT_DIVISOR;
 
+            // Wenn keine Y Daten zum Splitten vorhanden sind (bei GV und SV), nicht splitten
+            if (splittedSize == 0) {
+                return;
+            }
+
             List<List<List<Integer>>> splittedSeriesEntriesData = ListUtils.partition(
                     ladeZaehldatenHeatmap.getSeriesEntriesFirstChart(),
                     splittedSize);


### PR DESCRIPTION
# Description

Fixes a bug, where an error was thrown, when only SV% and/or GV% were selected for an 2x4h counting.

# Issue References

FV-427
 
# Definition of Done

<!-- Check all completed DoD requirements here -->

- [x] Acceptance criteria are met
- [x] Testing is done (unit-tests, DEV-environment)
- [x] Build/Test workflow has successfully finished
- [x] Release notes are complemented
- [x] Documentation is complemented (operator manual, system specification, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved heatmap handling when no Y-axis data is available.
  * Prevented invalid chart splitting for empty GV% and SV% series.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->